### PR TITLE
fix for https://github.com/juretta/hudson-github-plugin/issues/1

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
@@ -19,8 +19,8 @@ import org.apache.commons.jelly.XMLOutput;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
-import org.spearce.jgit.transport.RemoteConfig;
-import org.spearce.jgit.transport.URIish;
+import org.eclipse.jgit.transport.RemoteConfig;
+import org.eclipse.jgit.transport.URIish;
 
 import java.io.File;
 import java.io.IOException;


### PR DESCRIPTION
to make it work with my version of jenkins i had to switch back to

> import org.spearce.jgit.transport.RemoteConfig;
> import org.spearce.jgit.transport.URIish;

you might want to keep the eclipse version
