### PR TITLE
Adding ssh://git@github.com/x/x.git  support for post commit hook

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
@@ -266,6 +266,7 @@ public class GitHubPushTrigger extends Trigger<AbstractProject> implements Runna
     private static final Pattern[] URL_PATTERNS = {
         Pattern.compile("git@github.com:([^/.]+)/([^/.]+).git"),
         Pattern.compile("https://[^/.]+@github.com/([^/.]+)/([^/.]+).git"),
-        Pattern.compile("git://github.com/([^/.]+)/([^/.]+).git")
+        Pattern.compile("git://github.com/([^/.]+)/([^/.]+).git"),
+        Pattern.compile("ssh://git@github.com/([^/.]+)/([^/.]+).git")
     };
 }


### PR DESCRIPTION
Simply added: 
<code>ssh://git@github.com/([^/.]+)/([^/.]+).git</code>
as a valid SCM url
