### PR TITLE
Fix URL_PATTERNS

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
@@ -264,8 +264,8 @@ public class GitHubPushTrigger extends Trigger<AbstractProject> implements Runna
     private static final Logger LOGGER = Logger.getLogger(GitHubPushTrigger.class.getName());
 
     private static final Pattern[] URL_PATTERNS = {
-        Pattern.compile("git@github.com:([^/.]+)/([^/.]+).git"),
-        Pattern.compile("https://[^/.]+@github.com/([^/.]+)/([^/.]+).git"),
-        Pattern.compile("git://github.com/([^/.]+)/([^/.]+).git")
+        Pattern.compile("git@github.com:([^/.]+)/([^/.]+)(.git)?"),
+        Pattern.compile("https://[^/.]+@github.com/([^/.]+)/([^/.]+)(.git)?"),
+        Pattern.compile("git://github.com/([^/.]+)/([^/.]+)(.git)?")
     };
 }


### PR DESCRIPTION
The trailing `.git` is optional, but the patterns require it to be present.
