### PR TITLE
Accept github uris in the form github-xxx

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
@@ -269,9 +269,7 @@ public class GitHubPushTrigger extends Trigger<AbstractProject> implements Runna
         Pattern.compile("git://github.com/([^/]+)/([^/]+).git"),
         Pattern.compile("ssh://git@github.com/([^/]+)/([^/]+).git"),
 
-        Pattern.compile("git@github-([^/]+):([^/]+)/([^/]+).git"),
-        Pattern.compile("https://[^/]+@github-([^/]+)/([^/]+)/([^/]+).git"),
-        Pattern.compile("git://github-([^/]+)/([^/]+)/([^/]+).git"),
-        Pattern.compile("ssh://git@github-([^/]+)/([^/]+)/([^/]+).git")
+        Pattern.compile("git@github-[^/]+:([^/]+)/([^/]+).git"),
+        Pattern.compile("ssh://git@github-[^/]+/([^/]+)/([^/]+).git")
     };
 }


### PR DESCRIPTION
We use jenkins for github private repositories.
In order to automate the jenkins deployment, we also use chef, which generates us a SSH key for every project, key which we add as a deploy key on the repository.

Therefore, we need to be able to have different keys depending of the project.
In order to do that, we follow this : http://help.github.com/multiple-ssh-keys/

Therefore, our github uri looks like the following : `github-project`.
This fixes the uri recognition to match those kind of uris.
