### PR TITLE
Fixed a broken URL.

### DIFF
--- a/src/main/java/com/coravy/hudson/plugins/github/GithubUrl.java
+++ b/src/main/java/com/coravy/hudson/plugins/github/GithubUrl.java
@@ -60,7 +60,7 @@ public final class GithubUrl {
      * @return URL String (e.g. http://github.com/juretta/hudson-github-plugin/commit/5e31203faea681c41577b685818a361089fac1fc)
      */
     public String commitId(final String id) {
-        return new StringBuilder().append(baseUrl).append("commit/").append(id).toString();
+        return new StringBuilder().append(baseUrl).append("commits/").append(id).toString();
     }
 
 }


### PR DESCRIPTION
I found a small bug in the github commit link. Should link to commits/:sha, not commit/:sha
