### PR TITLE
Fixed private Organization-based repos

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubRepositoryName.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubRepositoryName.java
@@ -1,6 +1,7 @@
 package com.cloudbees.jenkins;
 
 import hudson.util.AdaptedIterator;
+import org.kohsuke.github.GHOrganization;
 import org.kohsuke.github.GHPerson;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
@@ -59,11 +60,11 @@ public class GitHubRepositoryName {
                 return new AdaptedIterator<GitHub,GHRepository>(GitHubWebHook.get().login(host,userName)) {
                     protected GHRepository adapt(GitHub item) {
                         try {
-                            GHPerson person = item.getUser(userName);
-                            if (person != null) {
-                                return person.getRepository(repositoryName);
+                            GHRepository repo = item.getUser(userName).getRepository(repositoryName);
+                            if (repo == null) {
+                                repo = item.getOrganization(userName).getRepository(repositoryName);
                             }
-                            return item.getOrganization(userName).getRepository(repositoryName);
+                            return repo;
                         } catch (IOException e) {
                             LOGGER.log(Level.WARNING,"Failed to obtain repository "+this,e);
                             return null;


### PR DESCRIPTION
It wasn't possible to use a private organization-based repo and have Jenkins auto-manage the hook url.  This fixes authentication/access for those repos.

It requires the fix to github-api found here:  https://github.com/kohsuke/github-api/pull/3
