### PR TITLE
URL normalisation corrupts urls where the project name legitimately ends in 'tree/'

### DIFF
--- a/src/main/java/com/coravy/hudson/plugins/github/GithubUrl.java
+++ b/src/main/java/com/coravy/hudson/plugins/github/GithubUrl.java
@@ -20,9 +20,9 @@ public final class GithubUrl {
         if (StringUtils.isBlank(url)) {
             return null;
         }
-        // Strip "tree/..."
-        if (url.contains("tree/")) {
-            url = url.replaceFirst("tree/.*$", "");
+        // Strip "/tree/..."
+        if (url.contains("/tree/")) {
+            url = url.replaceFirst("/tree/.*$", "");
         }
         if (!url.endsWith("/")) {
             url += '/';


### PR DESCRIPTION
Fixed the URL check to look for /tree/ as a complete fragment.
This was breaking our jenkins-github setup because our repo is actually called 'XXXtree'.
