### PR TITLE
Change GitHubPushCause to extend from SCMTriggerCause

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubPushCause.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubPushCause.java
@@ -1,6 +1,5 @@
 package com.cloudbees.jenkins;
 
-import hudson.model.Cause;
 import hudson.triggers.SCMTrigger.SCMTriggerCause;
 
 /**


### PR DESCRIPTION
My team uses the github plugin in conjunction with the Sonar software metrics plugin.
Sonar has an option 'Skip if triggered by SCM Changes' which currently does not seem to work with builds triggered by a github service hook.

If `GitHubPushCause` extends from `SCMTriggerCause` instead of `Cause` the sonar option works as expected.
