### PR TITLE
Match ssh://git@github.com:user/repo.git URLs

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubRepositoryName.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubRepositoryName.java
@@ -30,7 +30,8 @@ public class GitHubRepositoryName {
         Pattern.compile("https://[^/]+@([^/]+)/([^/]+)/([^/]+).git"),
         Pattern.compile("https://([^/]+)/([^/]+)/([^/]+).git"),
         Pattern.compile("git://([^/]+)/([^/]+)/([^/]+).git"),
-        Pattern.compile("ssh://git@([^/]+)/([^/]+)/([^/]+).git")
+        Pattern.compile("ssh://git@([^/]+)/([^/]+)/([^/]+).git"),
+        Pattern.compile("ssh://git@(.+):([^/]+)/([^/]+).git")
     };
 
     /**

--- a/src/test/java/com/coravy/hudson/plugins/github/GitHubRepositoryNameTest.java
+++ b/src/test/java/com/coravy/hudson/plugins/github/GitHubRepositoryNameTest.java
@@ -23,6 +23,16 @@ public class GitHubRepositoryNameTest {
     }
 
     @Test
+    public void gitAtUrlGitHubSsh() {
+        GitHubRepositoryName repo = GitHubRepositoryName
+                .create("ssh://git@github.com:jenkinsci/jenkins.git");
+        assertNotNull(repo);
+        assertEquals("jenkinsci", repo.userName);
+        assertEquals("jenkins", repo.repositoryName);
+        assertEquals("github.com", repo.host);
+    }
+
+    @Test
     public void gitAtUrlOtherHost() {
         GitHubRepositoryName repo = GitHubRepositoryName
                 .create("git@gh.company.com:jenkinsci/jenkins.git");


### PR DESCRIPTION
The GitHubRepositoryName class previously matched git@github.com:user/repo.git, but not the same URL with the ssh prefix: ssh://git@github.com:user/repo.git.
