### PR TITLE
handle non-suffixed github urls

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubRepositoryName.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubRepositoryName.java
@@ -26,11 +26,11 @@ import java.util.regex.Pattern;
 public class GitHubRepositoryName {
 
     private static final Pattern[] URL_PATTERNS = {
-        Pattern.compile("git@(.+):([^/]+)/([^/]+)(\\.git|)"),
-        Pattern.compile("https://[^/]+@([^/]+)/([^/]+)/([^/]+)(\\.git|)"),
-        Pattern.compile("https://([^/]+)/([^/]+)/([^/]+)(\\.git|)"),
-        Pattern.compile("git://([^/]+)/([^/]+)/([^/]+)(\\.git|)"),
-        Pattern.compile("ssh://git@([^/]+)/([^/]+)/([^/]+)(\\.git|)")
+        Pattern.compile("git@(.+):([^/]+)/([^/]+?).git"),
+        Pattern.compile("https://[^/]+@([^/]+)/([^/]+?)/([^/]+).git"),
+        Pattern.compile("https://([^/]+)/([^/]+)/([^/]+?).git"),
+        Pattern.compile("git://([^/]+)/([^/]+)/([^/]+?).git"),
+        Pattern.compile("ssh://git@([^/]+)/([^/]+)/([^/]+?).git")
     };
 
     /**
@@ -41,7 +41,13 @@ public class GitHubRepositoryName {
      * @return parsed {@link GitHubRepositoryName} or null if it cannot be
      *         parsed from the specified URL
      */
-    public static GitHubRepositoryName create(final String url) {
+    public static GitHubRepositoryName create(final String rawurl) {
+    	String url;
+    	if(rawurl.endsWith(".git")) {
+    		url = rawurl;
+    	} else {
+    		url = rawurl + ".git";
+    	}
         for (Pattern p : URL_PATTERNS) {
             Matcher m = p.matcher(url);
             if (m.matches())

--- a/src/test/java/com/coravy/hudson/plugins/github/GitHubRepositoryNameTest.java
+++ b/src/test/java/com/coravy/hudson/plugins/github/GitHubRepositoryNameTest.java
@@ -72,6 +72,17 @@ public class GitHubRepositoryNameTest {
         assertEquals("jenkins", repo.repositoryName);
         assertEquals("github.com", repo.host);
     }
+    
+    @Test
+    public void httpsUrlGitHubWithoutUserOrSuffix() {
+        //this is valid for anonymous usage
+        GitHubRepositoryName repo = GitHubRepositoryName
+                .create("https://github.com/jenkinsci/jenkins");
+        assertNotNull(repo);
+        assertEquals("jenkinsci", repo.userName);
+        assertEquals("jenkins", repo.repositoryName);
+        assertEquals("github.com", repo.host);
+    }
 
 
     @Test


### PR DESCRIPTION
Github sometimes sends urls without ".git". I don't know the conditions under which that happens. 
This simply patches up incoming urls to add the suffix.
