### PR TITLE
Add case of no tirgger from github, Use SCM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <groupId>com.coravy.hudson.plugins.github</groupId>
   <artifactId>github</artifactId>
   <packaging>hpi</packaging>
-  <version>1.7-SNAPSHOT</version>
+  <version>1.7.1-SNAPSHOT</version>
   <name>GitHub plugin</name>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Github+Plugin</url>
 

--- a/src/main/java/com/cloudbees/jenkins/GitHubCommitNotifier.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubCommitNotifier.java
@@ -2,13 +2,9 @@ package com.cloudbees.jenkins;
 
 import hudson.Extension;
 import hudson.Launcher;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.BuildListener;
-import hudson.model.Describable;
-import hudson.model.Descriptor;
-import hudson.model.Result;
+import hudson.model.*;
 import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.UserRemoteConfig;
 import hudson.plugins.git.util.BuildData;
 import hudson.scm.SCM;
 import hudson.tasks.BuildStepDescriptor;
@@ -16,12 +12,9 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
 import org.eclipse.jgit.lib.ObjectId;
-import org.eclipse.jgit.transport.RemoteConfig;
-import org.eclipse.jgit.transport.URIish;
+import org.jenkinsci.plugins.multiplescms.MultiSCM;
 import org.kohsuke.github.GHCommitState;
-import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHRepository;
-import org.kohsuke.github.GitHub;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
@@ -49,29 +42,57 @@ public class GitHubCommitNotifier extends Notifier {
         String sha1 = ObjectId.toString(buildData.getLastBuiltRevision().getSha1());
 
         GitHubTrigger trigger = (GitHubTrigger) build.getProject().getTrigger(GitHubPushTrigger.class);
-        for (GitHubRepositoryName gitHubRepositoryName : trigger.getGitHubRepositories()) {
-            for (GHRepository repository : gitHubRepositoryName.resolve()) {
-                GHCommitState state;
-                String msg;
+        if(trigger != null && !trigger.getGitHubRepositories().isEmpty()){
+            return performByTrigger(trigger,build,listener,sha1);
+        }else{
+            return performBySCM(build.getProject().getScm(), build, listener, sha1);
+        }
+    }
 
-                Result result = build.getResult();
-                if (result.isBetterOrEqualTo(SUCCESS)) {
-                    state = GHCommitState.SUCCESS;
-                    msg = "Success";
-                } else if (result.isBetterOrEqualTo(UNSTABLE)) {
-                    state = GHCommitState.FAILURE;
-                    msg = "Unstable";
-                } else {
-                    state = GHCommitState.ERROR;
-                    msg = "Failed";
-                }
-
-                listener.getLogger().println("setting commit status on Github for " + repository.getUrl() + "/commit/" + sha1);
-                repository.createCommitStatus(sha1, state, build.getAbsoluteUrl(), msg);
+    private boolean performBySCM(SCM scm,AbstractBuild<?, ?> build, BuildListener listener, String sha1) throws InterruptedException, IOException {
+        if (Hudson.getInstance().getPlugin("multiple-scms") != null&& scm instanceof MultiSCM) {
+            throw new  InterruptedException ("multiple-scms not supported for polling, please use Github trigger");
+        }
+        if (scm instanceof GitSCM) {
+            GitSCM gitSCM = (GitSCM) scm;
+            for (UserRemoteConfig urc: gitSCM.getUserRemoteConfigs()){
+                GitHubSCM gitHubPolling = GitHubSCM.create(urc.getUrl());
+                GHRepository repository = gitHubPolling.getGitHubRepo();
+                createStatus(repository, build, listener,sha1);
             }
         }
         return true;
     }
+
+    private boolean performByTrigger(GitHubTrigger trigger, AbstractBuild<?, ?> build,BuildListener listener,String sha1) throws IOException{
+        for (GitHubRepositoryName gitHubRepositoryName : trigger.getGitHubRepositories()) {
+            for (GHRepository repository : gitHubRepositoryName.resolve()) {
+                createStatus(repository, build, listener,sha1);
+            }
+        }
+        return true;
+    }
+
+    private void createStatus(GHRepository repository, AbstractBuild<?, ?> build, BuildListener listener, String sha1) throws IOException {
+        GHCommitState state;
+        String msg;
+
+        Result result = build.getResult();
+        if (result.isBetterOrEqualTo(SUCCESS)) {
+            state = GHCommitState.SUCCESS;
+            msg = "Success";
+        } else if (result.isBetterOrEqualTo(UNSTABLE)) {
+            state = GHCommitState.FAILURE;
+            msg = "Unstable";
+        } else {
+            state = GHCommitState.ERROR;
+            msg = "Failed";
+        }
+
+        listener.getLogger().println("setting commit status on Github for " + repository.getUrl() + "/commit/" + sha1);
+        repository.createCommitStatus(sha1, state, build.getAbsoluteUrl(), msg);
+    }
+
 
     @Extension
     public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {

--- a/src/main/java/com/cloudbees/jenkins/GitHubSCM.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubSCM.java
@@ -1,0 +1,89 @@
+package com.cloudbees.jenkins;
+
+import hudson.util.Secret;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GitHub;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.logging.Level.WARNING;
+
+public class GitHubSCM {
+
+    private static final Pattern[] URL_PATTERNS = {
+            Pattern.compile("https://([^/]+):([^/]+)@.*/([^/]+/[^/]+).git")
+    };
+
+    private String url;
+    private String userName;
+    private String password;
+    private String repositoryName;
+
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getRepositoryName(){
+        return repositoryName;
+    }
+
+    private static final Logger LOGGER = Logger.getLogger(GitHubSCM.class.getName());
+
+    private GitHubSCM(String url, String userName, String password, String repositoryName){
+        this.url = url;
+        this.userName = userName;
+        this.password = password;
+        this.repositoryName = repositoryName;
+    }
+
+    public Iterable<GitHub> login() {
+        Credential c = new Credential(userName, Secret.fromString(password), null, null);
+        try {
+            return Collections.singleton(c.login());
+        } catch (IOException e) {
+            LOGGER.log(WARNING,"Failed to login with username="+c.username,e);
+            return Collections.emptyList();
+        }
+    }
+
+
+    public GHRepository getGitHubRepo(){
+        Iterator<GitHub> GHIter = login().iterator();
+        if(GHIter.hasNext()){
+            GitHub gitHub = GHIter.next();
+            try {
+                return gitHub.getRepository(repositoryName);
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING,"Failed to obtain repository ",e);
+                return null;
+            }
+        }
+        return null;
+    }
+
+    public static GitHubSCM create(final String url){
+        for (Pattern p : URL_PATTERNS) {
+            Matcher m = p.matcher(url);
+            if (m.matches()){
+                return new GitHubSCM("https://api.github.com",m.group(1),m.group(2),m.group(3));
+            }
+        }
+        return null;
+    }
+
+}

--- a/src/test/java/com/coravy/hudson/plugins/github/GitHubSCMTest.java
+++ b/src/test/java/com/coravy/hudson/plugins/github/GitHubSCMTest.java
@@ -1,0 +1,28 @@
+package com.coravy.hudson.plugins.github;
+
+
+import com.cloudbees.jenkins.GitHubSCM;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: alon
+ * Date: 5/12/13
+ * Time: 5:12 PM
+ * To change this template use File | Settings | File Templates.
+ */
+public class GitHubSCMTest {
+
+    @Test
+    public void GitHubPollingCreateTest() {
+        GitHubSCM repo = GitHubSCM.create("https://user:pass@github.com/kenshoo/github-plugin.git");
+        assertNotNull(repo);
+        assertEquals("user", repo.getUserName());
+        assertEquals("pass", repo.getPassword());
+        assertEquals("kenshoo/github-plugin", repo.getRepositoryName());
+        assertEquals("https://api.github.com", repo.getUrl());
+    }
+}


### PR DESCRIPTION
Our Jenkins is local Ethernet and is not open to triggers from github.
We add the option to use the plug in taking the credential from the SCM section in jenkins.
for example:
https://user:password@github.com/kenshoo/github-plugin.git
1. Check if no triggers.
2. Get the credential from the SCM.
3. Login to github
4. Get the github repository.
5. Set the build status to the branch/pull request 
