### PR TITLE
cachedThreadPool polling

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
@@ -255,7 +255,7 @@ public class GitHubPushTrigger extends Trigger<AbstractProject<?,?>> implements 
 
     @Extension
     public static class DescriptorImpl extends TriggerDescriptor {
-        private transient final SequentialExecutionQueue queue = new SequentialExecutionQueue(Executors.newSingleThreadExecutor());
+        private transient final SequentialExecutionQueue queue = new SequentialExecutionQueue(Executors.newCachedThreadPool());
 
         private boolean manageHook;
         private String hookUrl;


### PR DESCRIPTION
When longer-running jobs have multiple pushes, it will cause blocks on other projects' github triggers.  

The culprit appears to be a combination of a job requiring a lock on its workspace to poll (fast-remote polling is not ideal) during a running build, and the singleThreadExecutor.  

By changing to cachedThreadpool, no projects get held up and the system is not overloaded.
