### PR TITLE
Don't force GitHub repository URLs to end in .git.

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubRepositoryName.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubRepositoryName.java
@@ -26,11 +26,11 @@ import java.util.regex.Pattern;
 public class GitHubRepositoryName {
 
     private static final Pattern[] URL_PATTERNS = {
-        Pattern.compile("git@(.+):([^/]+)/([^/]+).git"),
-        Pattern.compile("https://[^/]+@([^/]+)/([^/]+)/([^/]+).git"),
-        Pattern.compile("https://([^/]+)/([^/]+)/([^/]+).git"),
-        Pattern.compile("git://([^/]+)/([^/]+)/([^/]+).git"),
-        Pattern.compile("ssh://git@([^/]+)/([^/]+)/([^/]+).git")
+        Pattern.compile("git@(.+):([^/]+)/([^/]+)(?:.git)?"),
+        Pattern.compile("https://[^/]+@([^/]+)/([^/]+)/([^/]+)(?:.git)?"),
+        Pattern.compile("https://([^/]+)/([^/]+)/([^/]+)(?:.git)?"),
+        Pattern.compile("git://([^/]+)/([^/]+)/([^/]+)(?:.git)?"),
+        Pattern.compile("ssh://git@([^/]+)/([^/]+)/([^/]+)(?:.git)?")
     };
 
     /**


### PR DESCRIPTION
GitHub is relaxed about whether or not a repository URL ends with the .git string.  To them `git@github.com:jenkinsci/github-plugin.git` and `git@github.com:jenkinsci/github-plugin` mean exactly the same thing.  This change makes it so that Jenkins GitHub plugin does the same.
