### PR TITLE
JENKINS-20201 NPE when saving/updating jobs 

### DIFF
--- a/src/main/java/com/coravy/hudson/plugins/github/GithubProjectProperty.java
+++ b/src/main/java/com/coravy/hudson/plugins/github/GithubProjectProperty.java
@@ -79,18 +79,18 @@ public final class GithubProjectProperty extends
         @Override
         public JobProperty<?> newInstance(StaplerRequest req,
                 JSONObject formData) throws FormException {
-            try{
                 GithubProjectProperty tpp = req.bindJSON(
-            
                     GithubProjectProperty.class, formData);
+                
+                if(tpp == null){
+                	LOGGER.info("Couldn't bind JSON");
+                	return null;
+                }
                 if (tpp.projectUrl == null) {
                   tpp = null; // not configured
-                  }
+                  LOGGER.info("projectUrl not found, nullifying GithubProjectProperty");
+                }
                 return tpp;
-            } catch(NullPointerException e){
-            	LOGGER.info("Couldn't find Github project URL");
-            	return null;
-            }
         }
 
     }


### PR DESCRIPTION
We had a problem after upgrading to version 1.8 on Jenkins 1.536 installed via yum on CentOS-6.4 from http://pkg.jenkins-ci.org/redhat/. We are using this in conjunction with the github-oauth plugin.

When we tried to save or update existing jobs we were getting NPEs calling the GithubProjectProperty.projectUrl, this change returns null in the catch in keeping with the if(tcc.projectUrl == null) check. This PR allows for the `tpp` object to be null but also allows `tpp.profileUrl` to be null too and behave as the original call did.
