### PR TITLE
Adds a CrumbExclusion for the GitHub WebHook page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.445</version>
+    <version>1.448</version>
   </parent>
 
   <groupId>com.coravy.hudson.plugins.github</groupId>

--- a/src/main/java/com/cloudbees/jenkins/GitHubWebHook.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubWebHook.java
@@ -37,6 +37,7 @@ import static java.util.logging.Level.*;
 @Extension
 public class GitHubWebHook implements UnprotectedRootAction {
     private static final Pattern REPOSITORY_NAME_PATTERN = Pattern.compile("https?://([^/]+)/([^/]+)/([^/]+)");
+    public static final String URLNAME = "github-webhook";
 
     public String getIconFileName() {
         return null;
@@ -47,7 +48,7 @@ public class GitHubWebHook implements UnprotectedRootAction {
     }
 
     public String getUrlName() {
-        return "github-webhook";
+        return URLNAME;
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/GitHubWebHookCrumbExclusion.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubWebHookCrumbExclusion.java
@@ -1,0 +1,32 @@
+package com.cloudbees.jenkins;
+
+import hudson.Extension;
+import hudson.security.csrf.CrumbExclusion;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+@Extension
+public class GitHubWebHookCrumbExclusion extends CrumbExclusion {
+
+	private static final Logger LOGGER = Logger.getLogger("com.cloudbees.jenkins.GitHubWebHookCrumbExclusion");
+
+	@Override
+	public boolean process(HttpServletRequest req, HttpServletResponse resp, FilterChain chain) throws IOException, ServletException {
+		String pathInfo = req.getPathInfo();
+		if (pathInfo != null && pathInfo.equals(getExclusionPath())) {
+			chain.doFilter(req, resp);
+			return true;
+		}
+		return false;
+	}
+
+	public String getExclusionPath() {
+		return "/" + GitHubWebHook.URLNAME + "/";
+	}
+}


### PR DESCRIPTION
The GitHub webhook endpoint should not be protected by the CSRF protection built into Jenkins. This commit adds a CrumbExclusion filter so that the endpoint created by c.c.j.GitHubWebHook is not protected using the CSRF crumb protection scheme.

Also bumps Jenkins API version (required for CrumbExclusion).
