### PR TITLE
[WiP] - rely on GitStatus.notifyCommit to trigger a build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,9 @@
       <version>1.42</version>
     </dependency>
     <dependency>
-      <groupId>org.jenkinsci.plugins</groupId>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>1.1.17</version>
+      <version>2.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.jmock</groupId>

--- a/src/main/java/com/cloudbees/jenkins/GitHubTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubTrigger.java
@@ -4,6 +4,7 @@ import hudson.Extension;
 import hudson.Util;
 import hudson.model.AbstractProject;
 import hudson.triggers.Trigger;
+import org.eclipse.jgit.transport.URIish;
 
 import java.util.Collection;
 import java.util.Set;
@@ -19,8 +20,11 @@ public interface GitHubTrigger {
     @Deprecated
     public void onPost();
 
-    // TODO: document me
+    @Deprecated
     public void onPost(String triggeredByUser);
+
+    public void onPost(String triggeredByUser, URIish repository, String sha1, String ref);
+
     /**
      * Obtains the list of the repositories that this trigger is looking at.
      *


### PR DESCRIPTION
github post commit hook [payload](https://help.github.com/articles/post-receive-hooks) contains enough information to trigger a build using git plugin GitStatus.notifyCommit