### PR TITLE
fix unclosed github-polling.log files

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
@@ -76,6 +76,7 @@ public class GitHubPushTrigger extends Trigger<AbstractProject<?,?>> implements 
                             logger.println("Changes found");
                         else
                             logger.println("No changes");
+                        listener.close();
                         return result;
                     } catch (Error e) {
                         e.printStackTrace(listener.error("Failed to record SCM polling"));


### PR DESCRIPTION
this plugin leaves many unclosed github-polling.log files (e.g., currently 7522). this causes other build processes to be unable to open files ("Too many open files" error), which in turn causes false build failures due to nonzero exit statuses.
