### PR TITLE
Build step to set Github commit status as "pending"

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubPendingCommitStatus.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubPendingCommitStatus.java
@@ -1,0 +1,51 @@
+package com.cloudbees.jenkins;
+
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.tasks.Builder;
+import hudson.model.BuildListener;
+import hudson.model.Descriptor;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.model.AbstractProject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import hudson.plugins.git.util.BuildData;
+import org.eclipse.jgit.lib.ObjectId;
+import org.kohsuke.github.GHCommitState;
+import org.kohsuke.github.GHRepository;
+
+import java.io.IOException;
+
+@Extension
+public class GitHubPendingCommitStatus extends Builder {
+    @DataBoundConstructor
+    public GitHubPendingCommitStatus() {
+    }
+
+    @Override
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        BuildData buildData = build.getAction(BuildData.class);
+        String sha1 = ObjectId.toString(buildData.getLastBuiltRevision().getSha1());
+
+        for (GitHubRepositoryName name : GitHubRepositoryNameContributor.parseAssociatedNames(build.getProject())) {
+            for (GHRepository repository : name.resolve()) {
+                listener.getLogger().println(Messages.GitHubCommitNotifier_SettingCommitStatus(repository.getUrl() + "/commit/" + sha1));
+                repository.createCommitStatus(sha1, GHCommitState.PENDING, build.getAbsoluteUrl(), Messages.CommitNotifier_Pending(build.getDisplayName()));
+            }
+        }
+        return true;
+    }
+
+    @Extension
+    public static class Descriptor extends BuildStepDescriptor<Builder> {
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            return true;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Set build status to \"pending\" on GitHub commit";
+        }
+    }
+}

--- a/src/main/resources/com/cloudbees/jenkins/Messages.properties
+++ b/src/main/resources/com/cloudbees/jenkins/Messages.properties
@@ -1,4 +1,5 @@
 CommitNotifier.Success=Build {0} succeeded in {1}
 CommitNotifier.Unstable=Build {0} found unstable in {1}
 CommitNotifier.Failed=Build {0} failed in {1}
+CommitNotifier.Pending=Build {0} in progress...
 GitHubCommitNotifier.SettingCommitStatus=Setting commit status on GitHub for {0}


### PR DESCRIPTION
add new build step which marks the relevant commit as “pending” using the github status api.

fixed webhook login to work with github enterprise, enabling calls to status api to succeed for both pending and final build statuses
