### PR TITLE
[WiP] - JENKINS-24702

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,12 +28,17 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>github-api</artifactId>
-      <version>1.42</version>
+      <version>1.58</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
       <version>2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+      <version>1.9.3</version>
     </dependency>
     <dependency>
       <groupId>org.jmock</groupId>

--- a/src/main/java/com/cloudbees/jenkins/Credential.java
+++ b/src/main/java/com/cloudbees/jenkins/Credential.java
@@ -1,14 +1,5 @@
 package com.cloudbees.jenkins;
 
-import hudson.Extension;
-import hudson.Util;
-import hudson.model.AbstractDescribableImpl;
-import hudson.model.Descriptor;
-import hudson.util.FormValidation;
-import hudson.util.Secret;
-import org.kohsuke.github.GitHub;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
 
 import java.io.IOException;
 
@@ -17,44 +8,19 @@ import java.io.IOException;
  *
  * @author Kohsuke Kawaguchi
  */
-public class Credential extends AbstractDescribableImpl<Credential> {
-    public final String username;
-    public final String apiUrl;
-    public final String oauthAccessToken;
+@Deprecated
+public class Credential extends GitHubServerConfig {
 
-    @DataBoundConstructor
-    public Credential(String username, String apiUrl, String oauthAccessToken) {
-        this.username = username;
-        this.apiUrl = apiUrl;
-        this.oauthAccessToken = oauthAccessToken;
+    public transient String username;
+    public transient String oauthAccessToken;
+
+    private Credential(String apiUrl, String credentialId) {
+        super(apiUrl, credentialId);
     }
 
-    public GitHub login() throws IOException {
-        if (Util.fixEmpty(apiUrl) != null) {
-            return GitHub.connectToEnterprise(apiUrl,oauthAccessToken);
-        }
-        return GitHub.connect(username,oauthAccessToken);
-    }
 
-    @Extension
-    public static class DescriptorImpl extends Descriptor<Credential> {
-        @Override
-        public String getDisplayName() {
-            return ""; // unused
-        }
-
-        public FormValidation doValidate(@QueryParameter String apiUrl, @QueryParameter String username, @QueryParameter String oauthAccessToken) throws IOException {
-            GitHub gitHub;
-            if (Util.fixEmpty(apiUrl) != null) {
-                gitHub = GitHub.connectToEnterprise(apiUrl,oauthAccessToken);
-            } else {
-                gitHub = GitHub.connect(username,oauthAccessToken);
             }
 
-            if (gitHub.isCredentialValid())
-                return FormValidation.ok("Verified");
-            else
-                return FormValidation.error("Failed to validate the account");
         }
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/Credential.java
+++ b/src/main/java/com/cloudbees/jenkins/Credential.java
@@ -1,7 +1,20 @@
 package com.cloudbees.jenkins;
 
+import com.cloudbees.jenkins.github.AccessTokenCredential;
+import com.cloudbees.jenkins.github.GitHubServerConfig;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
+import hudson.security.ACL;
+import jenkins.model.Jenkins;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static com.cloudbees.plugins.credentials.CredentialsScope.GLOBAL;
 
 /**
  * Credential to access GitHub.
@@ -18,9 +31,32 @@ public class Credential extends GitHubServerConfig {
         super(apiUrl, credentialId);
     }
 
+    // Migrate legacy data
+    private Object readResolve() {
 
+        if (credentialId != null) return this;
+
+        if (apiUrl == null) apiUrl = "https://api.github.com"; // org.kohsuke.github.GitHub.GITHUB_URL is private
+
+        // search for existing credentials
+        List<AccessTokenCredential> candidates = CredentialsProvider.lookupCredentials(AccessTokenCredential.class, Jenkins.getInstance(), ACL.SYSTEM,
+                URIRequirementBuilder.fromUri(apiUrl).build());
+        for (AccessTokenCredential candidate : candidates) {
+            if (candidate.getUsername().equals(username)) {
+                return new GitHubServerConfig(apiUrl, candidate.getId());
             }
-
         }
+
+        CredentialsStore store = CredentialsProvider.lookupStores(Jenkins.getInstance()).iterator().next();
+        AccessTokenCredential accessToken = new AccessTokenCredential(GLOBAL, null, apiUrl, apiUrl, username, oauthAccessToken);
+        try {
+            store.addCredentials(Domain.global(), accessToken);
+        } catch (IOException e) {
+            LOGGER.log(Level.SEVERE, "failed to migrate GitHub OAuth token to credentials store", e);
+        }
+
+        return new GitHubServerConfig(apiUrl, accessToken.getId());
     }
+
+    private static final Logger LOGGER = Logger.getLogger(Credential.class.getName());
 }

--- a/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
@@ -1,5 +1,6 @@
 package com.cloudbees.jenkins;
 
+import com.cloudbees.jenkins.github.GitHubServerConfig;
 import hudson.Extension;
 import hudson.Util;
 import hudson.console.AnnotatedLargeText;
@@ -8,6 +9,7 @@ import hudson.model.Hudson;
 import hudson.model.Hudson.MasterComputer;
 import hudson.model.Item;
 import hudson.model.AbstractProject;
+import hudson.model.Items;
 import hudson.model.Project;
 import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
@@ -224,9 +226,10 @@ public class GitHubPushTrigger extends Trigger<AbstractProject<?,?>> implements 
 
         private boolean manageHook;
         private String hookUrl;
-        private volatile List<Credential> credentials = new ArrayList<Credential>();
+        private volatile List<GitHubServerConfig> configs = new ArrayList<GitHubServerConfig>();
 
         public DescriptorImpl() {
+            Items.XSTREAM2.aliasAttribute("credentials", "configs");
             load();
         }
 
@@ -263,8 +266,8 @@ public class GitHubPushTrigger extends Trigger<AbstractProject<?,?>> implements 
             return hookUrl!=null;
         }
 
-        public List<Credential> getCredentials() {
-            return credentials;
+        public List<GitHubServerConfig> getConfigs() {
+            return configs;
         }
 
         @Override
@@ -277,7 +280,7 @@ public class GitHubPushTrigger extends Trigger<AbstractProject<?,?>> implements 
             } else {
                 hookUrl = null;
             }
-            credentials = req.bindJSONToList(Credential.class,hookMode.get("credentials"));
+            configs = req.bindJSONToList(GitHubServerConfig.class,hookMode.get("configs"));
             save();
             return true;
         }

--- a/src/main/java/com/cloudbees/jenkins/github/AccessTokenCredential.java
+++ b/src/main/java/com/cloudbees/jenkins/github/AccessTokenCredential.java
@@ -90,5 +90,20 @@ public class AccessTokenCredential extends BaseStandardCredentials implements St
             }
             return candidates;
         }
+
+
+        public FormValidation doValidate(@QueryParameter String apiUrl, @QueryParameter String username, @QueryParameter String oauthAccessToken) throws IOException {
+            GitHub gitHub;
+            if (Util.fixEmpty(apiUrl) != null) {
+                gitHub = GitHub.connectToEnterprise(apiUrl,oauthAccessToken);
+            } else {
+                gitHub = GitHub.connect(username,oauthAccessToken);
+            }
+
+            if (gitHub.isCredentialValid())
+                return FormValidation.ok("Verified");
+            else
+                return FormValidation.error("Failed to validate the account");
+        }
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/github/AccessTokenCredential.java
+++ b/src/main/java/com/cloudbees/jenkins/github/AccessTokenCredential.java
@@ -1,0 +1,94 @@
+package com.cloudbees.jenkins.github;
+
+import com.cloudbees.plugins.credentials.CredentialsDescriptor;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.AutoCompletionCandidates;
+import hudson.util.FormValidation;
+import hudson.util.Secret;
+import jenkins.model.Jenkins;
+import org.kohsuke.github.GHAuthorization;
+import org.kohsuke.github.GitHub;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class AccessTokenCredential extends BaseStandardCredentials implements StandardUsernameCredentials {
+
+    private final String githubServer;
+
+    private final String username;
+
+    private final Secret token;
+
+    @DataBoundConstructor
+    public AccessTokenCredential(CredentialsScope scope,
+                                 String id, String description,
+                                 String githubServer, String username, String token) {
+        super(scope, id, description);
+        this.githubServer = githubServer;
+        this.username = Util.fixNull(username);
+        this.token = Secret.fromString(token);
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public Secret getToken() {
+        return token;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends CredentialsDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return "Github Access Token";
+        }
+
+
+        public FormValidation doCreateToken(@QueryParameter("githubServer") String githubServer,
+                                            @QueryParameter("username") String username,
+                                            @QueryParameter("password") String password,
+                                            @QueryParameter("scope") String scopes) {
+
+
+            String[] sc = scopes.split("\\s*,[,\\s]*"); // GHAuthorization.REPO_STATUS, GHAuthorization.REPO
+
+            try {
+                GitHub gh = GitHub.connectToEnterprise(githubServer, username, password);
+                GHAuthorization token = gh.createToken(Arrays.asList(sc),
+                        "Jenkins GitHub Plugin", Jenkins.getInstance().getRootUrl());
+                return FormValidation.ok("Access token created: " + token.getToken());
+            } catch (IOException ex) {
+                return FormValidation.error("GitHub API token couldn't be created: " + ex.getMessage());
+            }
+        }
+
+        // TODO build from GHAuthorization.*, but require https://github.com/kohsuke/github-api/pull/128
+        final List<String> scopes = Arrays.asList("user", "user:email", "user:follow",
+                "public_repo", "repo", "repo_deployment", "repo:status", "delete_repo",
+                "notifications", "gist",
+                "read:repo_hook", "write:repo_hook", "admin:repo_hook",
+                "read:org", "write:org", "admin:org",
+                "read:public_key", "write:public_key", "admin :public_key");
+
+        public AutoCompletionCandidates doAutoCompleteScope(@QueryParameter String value) {
+            AutoCompletionCandidates candidates = new AutoCompletionCandidates();
+            for (String scope : scopes) {
+                if (scope.startsWith(value)) candidates.add(scope);
+            }
+            return candidates;
+        }
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/github/GitHubServerConfig.java
+++ b/src/main/java/com/cloudbees/jenkins/github/GitHubServerConfig.java
@@ -1,0 +1,53 @@
+package com.cloudbees.jenkins.github;
+
+import com.cloudbees.plugins.credentials.CredentialsMatcher;
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import hudson.security.ACL;
+import jenkins.model.Jenkins;
+import org.kohsuke.github.GitHub;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.IOException;
+import java.util.Collections;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class GitHubServerConfig extends AbstractDescribableImpl<GitHubServerConfig> {
+
+    public String apiUrl;
+    protected final String credentialId;
+
+    @DataBoundConstructor
+    public GitHubServerConfig(String apiUrl, String credentialId) {
+        this.apiUrl = apiUrl;
+        this.credentialId = credentialId;
+    }
+
+    public GitHub login() throws IOException {
+
+        AccessTokenCredential accessToken = (AccessTokenCredential) CredentialsMatchers.firstOrNull(
+                CredentialsProvider.lookupCredentials(AccessTokenCredential.class, Jenkins.getInstance(), ACL.SYSTEM, Collections.EMPTY_LIST),
+                CredentialsMatchers.withId(credentialId));
+
+        if (Util.fixEmpty(apiUrl) != null) {
+            return GitHub.connectToEnterprise(apiUrl,accessToken.getToken().getPlainText());
+        }
+        return GitHub.connect(accessToken.getUsername(),accessToken.getToken().getPlainText());
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<GitHubServerConfig> {
+        @Override
+        public String getDisplayName() {
+            return ""; // unused
+        }
+
+    }
+}

--- a/src/main/resources/com/cloudbees/jenkins/Credential/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/Credential/config.jelly
@@ -1,12 +1,8 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:c="/lib/credentials" xmlns:f="/lib/form">
   <f:entry title="${%API URL}" field="apiUrl">
     <f:textbox/>
   </f:entry>
-  <f:entry title="${%Username}" field="username">
-    <f:textbox/>
+  <f:entry title="${%Credentials}" field="credentialId">
+    <c:select/>
   </f:entry>
-  <f:entry title="${%OAuth token}" field="oauthAccessToken">
-    <f:textbox/>
-  </f:entry>
-  <f:validateButton title="${%Test Credential}" with="apiUrl,username,password,oauthAccessToken" method="validate"/>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/Credential/help-apiUrl.html
+++ b/src/main/resources/com/cloudbees/jenkins/Credential/help-apiUrl.html
@@ -1,5 +1,0 @@
-<div>
-    If you use GitHub Enterprise you may specify the API end point here
-    (e.g., "https://ghe.acme.com/api/v3/"). An OAuth token is required and
-    the password is ignored if you specify one.
-</div>

--- a/src/main/resources/com/cloudbees/jenkins/Credential/help-password.html
+++ b/src/main/resources/com/cloudbees/jenkins/Credential/help-password.html
@@ -1,3 +1,0 @@
-<div>
-    Password is no longer required if you specify an OAuth token.
-</div>

--- a/src/main/resources/com/cloudbees/jenkins/Credential/help-username.html
+++ b/src/main/resources/com/cloudbees/jenkins/Credential/help-username.html
@@ -1,4 +1,0 @@
-<div>
-    If your Jenkins uses multiple repositories that are spread across different
-    user accounts, you can list them all here.
-</div>

--- a/src/main/resources/com/cloudbees/jenkins/GitHubPushTrigger/global.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/GitHubPushTrigger/global.jelly
@@ -11,9 +11,9 @@
               </f:entry>
             </f:optionalBlock>
           </j:if>
-          <f:section title="${%GitHub Credentials}">
+          <f:section title="${%GitHub API}">
             <f:block>
-              <f:repeatable field="credentials" minimum="${1}" noAddButton="true">
+              <f:repeatable field="configs" minimum="${1}" noAddButton="true">
                 <table style="width:100%">
                   <st:include from="${descriptor}" page="${descriptor.configPage}" />
                   <f:entry>

--- a/src/main/resources/com/cloudbees/jenkins/github/AccessTokenCredential/credentials.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/github/AccessTokenCredential/credentials.jelly
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:invisibleEntry>
+        <f:textbox field="id"/>
+    </f:invisibleEntry>
+    <f:entry title="${%Description}" field="description">
+        <f:textbox/>
+    </f:entry>
+
+    <!-- TODO this should be defined as the scope for this credentials instance -->
+    <f:entry title="${%Github server}" field="githubServer">
+        <f:textbox default="https://api.github.com"/>
+    </f:entry>
+
+    <f:entry title="${%Username}" field="username">
+        <f:textbox/>
+    </f:entry>
+    <f:entry title="${%Access Token}" field="token">
+        <f:password/>
+    </f:entry>
+    <f:advanced title="generate Access Token">
+        <f:entry title="${%Password}" field="password">
+            <f:password />
+            <i>Jenkins only uses password to generate Access Token, it won't be stored on server.</i>
+        </f:entry>
+
+        <f:entry title="${%Scope}" field="scope">
+            <!-- TODO render as checkboxes ? -->
+            <f:textbox default="repo, public_repo, repo:status, admin:repo_hook" autoCompleteDelimChar="," />
+        </f:entry>
+
+        <!-- TODO capture FormValidation output when successful and paste to token field -->
+        <f:validateButton title="${%Create access token}" progress="${%Creating...}"
+                          method="createToken" with="githubServer,username,password,scope" />
+    </f:advanced>
+
+</j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/github/AccessTokenCredential/help-token.html
+++ b/src/main/resources/com/cloudbees/jenkins/github/AccessTokenCredential/help-token.html
@@ -1,0 +1,3 @@
+Access token is required to authentication Jenkins on GitHub API. You can generate one following
+<a href="https://help.github.com/articles/creating-an-access-token-for-command-line-use">github documentation</a>
+or use token generator just next.

--- a/src/main/resources/com/cloudbees/jenkins/github/GitHubServerConfig/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/github/GitHubServerConfig/config.jelly
@@ -1,6 +1,6 @@
 <j:jelly xmlns:j="jelly:core" xmlns:c="/lib/credentials" xmlns:f="/lib/form">
   <f:entry title="${%API URL}" field="apiUrl">
-    <f:textbox/>
+    <f:textbox default="https://api.github.com"/>
   </f:entry>
   <f:entry title="${%Credentials}" field="credentialId">
     <c:select/>

--- a/src/main/resources/com/cloudbees/jenkins/github/GitHubServerConfig/help-apiUrl.html
+++ b/src/main/resources/com/cloudbees/jenkins/github/GitHubServerConfig/help-apiUrl.html
@@ -1,0 +1,4 @@
+<div>
+    If you use GitHub Enterprise you may specify the API end point here
+    (e.g., "https://ghe.acme.com/api/v3/"). OAuth token authentication is required.
+</div>

--- a/src/test/java/com/cloudbees/jenkins/GitHubPushTriggerConfigSubmitTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GitHubPushTriggerConfigSubmitTest.java
@@ -4,7 +4,6 @@ import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.util.Secret;
 import java.net.URL;
-import java.util.List;
 import org.jvnet.hudson.test.HudsonTestCase;
 import org.kohsuke.stapler.Stapler;
 
@@ -25,18 +24,11 @@ public class GitHubPushTriggerConfigSubmitTest extends HudsonTestCase {
         f.getInputByValue("auto").setChecked(true);
         f.getInputByName("_.hookUrl").setChecked(true);
         f.getInputByName("url").setValueAttribute(WEBHOOK_URL);
-        f.getInputByName("_.username").setValueAttribute("jenkins");
         submit(f);
 
         GitHubPushTrigger.DescriptorImpl d = getDescriptor();
         assertTrue(d.isManageHook());
         assertEquals(new URL(WEBHOOK_URL), d.getHookUrl());
-
-        List<Credential> credentials = d.getCredentials();
-        assertNotNull(credentials);
-        assertEquals(1, credentials.size());
-        Credential credential = credentials.get(0);
-        assertEquals("jenkins", credential.username);
     }
 
     public void testConfigSubmit_ManuallyManageHook() throws Exception {


### PR DESCRIPTION
convert legacy credentials stored as plain text (including Oauth token :-\) to use credentials-plugin.
Maybe AccessTokenCredential is generic enough for this to be defined by some oauth-credentials plugin, not sure how portable this is and if this would make sense.