### PR TITLE
Use the combined status API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>github-api</artifactId>
-      <version>1.42</version>
+      <version>1.56</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/com/cloudbees/jenkins/GitHubCommitNotifier.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubCommitNotifier.java
@@ -43,33 +43,22 @@ import org.jenkinsci.plugins.github.util.BuildDataHelper;
 public class GitHubCommitNotifier extends Notifier {
 
     private final String resultOnFailure;
-    private final String statusReporterName;
     private static final Result[] SUPPORTED_RESULTS = {FAILURE, UNSTABLE, SUCCESS};
-    private static final String DEFAULT_STATUS_REPORTER_NAME = "jenkins";
-
+    
     @DataBoundConstructor
-    public GitHubCommitNotifier(String resultOnFailure, String statusReporterName) {
-        this.resultOnFailure = resultOnFailure;
-        this.statusReporterName = statusReporterName;
-    }
-
     public GitHubCommitNotifier(String resultOnFailure) {
-        this(resultOnFailure, DEFAULT_STATUS_REPORTER_NAME);
+        this.resultOnFailure = resultOnFailure;
     }
-
+    
     @Deprecated
     public GitHubCommitNotifier() {
-        this(getDefaultResultOnFailure().toString(), DEFAULT_STATUS_REPORTER_NAME);
+        this(getDefaultResultOnFailure().toString());
     }
 
     public @Nonnull String getResultOnFailure() {
         return resultOnFailure != null ? resultOnFailure : getDefaultResultOnFailure().toString();
     }
-
-    public @Nonnull String getStatusReporterName() {
-        return statusReporterName != null ? statusReporterName : DEFAULT_STATUS_REPORTER_NAME;
-    }
-
+     
     public static @Nonnull Result getDefaultResultOnFailure() {
         return SUPPORTED_RESULTS[0];
     }
@@ -108,9 +97,9 @@ public class GitHubCommitNotifier extends Notifier {
         }
         return true;
     }
-
-    private void updateCommitStatus(@Nonnull AbstractBuild<?, ?> build, @Nonnull BuildListener listener) throws InterruptedException, IOException {
-        final String sha1 = ObjectId.toString(BuildDataHelper.getCommitSHA1(build));
+        
+    private void updateCommitStatus(@Nonnull AbstractBuild<?, ?> build, @Nonnull BuildListener listener) throws InterruptedException, IOException {       
+        final String sha1 = ObjectId.toString(BuildDataHelper.getCommitSHA1(build));  
         for (GitHubRepositoryName name : GitHubRepositoryNameContributor.parseAssociatedNames(build.getProject())) {
             for (GHRepository repository : name.resolve()) {
                 GHCommitState state;
@@ -135,7 +124,7 @@ public class GitHubCommitNotifier extends Notifier {
                 }
 
                 listener.getLogger().println(Messages.GitHubCommitNotifier_SettingCommitStatus(repository.getUrl() + "/commit/" + sha1));
-                repository.createCommitStatus(sha1, state, build.getAbsoluteUrl(), msg, getStatusReporterName());
+                repository.createCommitStatus(sha1, state, build.getAbsoluteUrl(), msg);
             }
         }
     }

--- a/src/main/java/com/cloudbees/jenkins/GitHubCommitNotifier.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubCommitNotifier.java
@@ -124,7 +124,7 @@ public class GitHubCommitNotifier extends Notifier {
                 }
 
                 listener.getLogger().println(Messages.GitHubCommitNotifier_SettingCommitStatus(repository.getUrl() + "/commit/" + sha1));
-                repository.createCommitStatus(sha1, state, build.getAbsoluteUrl(), msg);
+                repository.createCommitStatus(sha1, state, build.getAbsoluteUrl(), msg, build.getFullDisplayName());
             }
         }
     }

--- a/src/main/resources/com/cloudbees/jenkins/GitHubCommitNotifier/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/GitHubCommitNotifier/config.jelly
@@ -4,7 +4,4 @@
             <f:select/>
         </f:entry>
     </f:advanced>
-    <f:entry title="${%Status reporter}" field="statusReporterName" default="jenkins">
-        <f:textbox/>
-    </f:entry>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/GitHubCommitNotifier/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/GitHubCommitNotifier/config.jelly
@@ -4,4 +4,7 @@
             <f:select/>
         </f:entry>
     </f:advanced>
+    <f:entry title="${%Status reporter}" field="statusReporterName" default="jenkins">
+        <f:textbox/>
+    </f:entry>
 </j:jelly>


### PR DESCRIPTION
This branch adds the "jenkins" context to statuses so other tools can update the status of a pull request in separate contexts.

More info:
https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref