### PR TITLE
Fix issue with jobs using the CloudBees folders plugin being deleted

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/Cleaner.java
+++ b/src/main/java/com/cloudbees/jenkins/Cleaner.java
@@ -52,7 +52,7 @@ public class Cleaner extends PeriodicWork {
         }
 
         // subtract all the live repositories
-        for (AbstractProject<?,?> job : Hudson.getInstance().getItems(AbstractProject.class)) {
+        for (AbstractProject<?,?> job : Hudson.getInstance().getAllItems(AbstractProject.class)) {
             GitHubPushTrigger trigger = job.getTrigger(GitHubPushTrigger.class);
             if (trigger!=null) {
                 names.removeAll(GitHubRepositoryNameContributor.parseAssociatedNames(job));


### PR DESCRIPTION
This should fix https://issues.jenkins-ci.org/browse/JENKINS-25127 - I tested it on my installation and it no longer deleting the hooks for jobs that are in folders