### PR TITLE
admin:repo_hook mention in help

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubWebHook.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubWebHook.java
@@ -149,14 +149,14 @@ public class GitHubWebHook implements UnprotectedRootAction {
         return new Function<AbstractProject, AbstractProject>() {
             @Override
             public AbstractProject apply(AbstractProject job) {
-                LOGGER.debug("Calling registerHooks() for {0}", notNull(job, "Job can't be null").getFullName());
+                LOGGER.debug("Calling registerHooks() for {}", notNull(job, "Job can't be null").getFullName());
 
                 // We should handle wrong url of self defined hook url here in any case with try-catch :(
                 URL hookUrl;
                 try {
                     hookUrl = Trigger.all().get(GitHubPushTrigger.DescriptorImpl.class).getHookUrl();
                 } catch (GHPluginConfigException e) {
-                    LOGGER.error("Skip registration of GHHook ({0})", e.getMessage());
+                    LOGGER.error("Skip registration of GHHook ({})", e.getMessage());
                     return job;
                 }
                 Runnable hookRegistrator = forHookUrl(hookUrl).registerFor(job);

--- a/src/main/resources/com/cloudbees/jenkins/GitHubPushTrigger/help-auto.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/GitHubPushTrigger/help-auto.jelly
@@ -3,7 +3,9 @@
     <div>
       In this mode, Jenkins will add/remove hook URLs to GitHub based on the project configuration of Jenkins.
       Jenkins has a single post-commit hook URL for all the repositories, and this URL will be added to
-      all the GitHub repositories Jenkins is interested in.
+      all the GitHub repositories Jenkins is interested in. You should provide credentials with scope 
+        <b>admin:repo_hook</b> for every repo which should be managed by Jenkins. It needs to read current list of hooks,
+        create new hooks and remove old.
 
       <p>
         This URL is <tt><a href="${rootURL}/github-webhook/">${app.rootUrl}github-webhook/</a></tt>,


### PR DESCRIPTION
You should provide credentials with scope 
**admin:repo_hook** for every repo which should be managed by Jenkins. It needs to read current list of hooks, create new hooks and remove old.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/62)
<!-- Reviewable:end -->
