### PR TITLE
use GlobalConfiguration extension point to store all global config

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github/config/GitHubPluginConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/github/config/GitHubPluginConfig.java
@@ -4,19 +4,21 @@ import com.cloudbees.jenkins.GitHubWebHook;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import hudson.Extension;
-import hudson.model.AbstractDescribableImpl;
+import hudson.XmlFile;
 import hudson.model.AbstractProject;
 import hudson.model.Descriptor;
 import hudson.util.FormValidation;
+import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
 import org.apache.commons.codec.binary.Base64;
 import org.jenkinsci.main.modules.instance_identity.InstanceIdentity;
 import org.jenkinsci.plugins.github.GitHubPlugin;
 import org.jenkinsci.plugins.github.internal.GHPluginConfigException;
+import org.jenkinsci.plugins.github.migration.Migrator;
 import org.kohsuke.github.GitHub;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static java.lang.String.format;
 import static org.jenkinsci.plugins.github.config.GitHubServerConfig.allowedToManageHooks;
 import static org.jenkinsci.plugins.github.config.GitHubServerConfig.loginToGithub;
 import static org.jenkinsci.plugins.github.util.FluentIterableWrapper.from;
@@ -41,31 +44,50 @@ import static org.jenkinsci.plugins.github.util.FluentIterableWrapper.from;
  * @author lanwen (Merkushev Kirill)
  * @since TODO
  */
-public class GitHubPluginConfig extends AbstractDescribableImpl<GitHubPluginConfig> {
+@Extension
+public class GitHubPluginConfig extends GlobalConfiguration {
     private static final Logger LOGGER = LoggerFactory.getLogger(GitHubPluginConfig.class);
+    public static final String GITHUB_PLUGIN_CONFIGURATION_ID = "github-plugin-configuration";
+
+    /**
+     * Helps to avoid null in {@link GitHubPlugin#configuration()}
+     */
+    public static final GitHubPluginConfig EMPTY_CONFIG =
+            new GitHubPluginConfig(Collections.<GitHubServerConfig>emptyList());
 
     private List<GitHubServerConfig> configs = new ArrayList<GitHubServerConfig>();
     private URL hookUrl;
     private transient boolean overrideHookUrl;
 
-    @DataBoundConstructor
+    /**
+     * Used to get current instance identity.
+     * It compared with same value when testing hook url availability in {@link #doCheckHookUrl(String)}
+     */
+    @Inject
+    @SuppressWarnings("unused")
+    private transient InstanceIdentity identity;
+
     public GitHubPluginConfig() {
+        load();
+    }
+
+    public GitHubPluginConfig(List<GitHubServerConfig> configs) {
+        this.configs = configs;
+    }
+
+    @SuppressWarnings("unused")
+    public void setConfigs(List<GitHubServerConfig> configs) {
+        this.configs = configs;
     }
 
     public List<GitHubServerConfig> getConfigs() {
         return configs;
     }
 
-    @DataBoundSetter
-    public void setConfigs(List<GitHubServerConfig> configs) {
-        this.configs = configs;
-    }
-
     public boolean isManageHooks() {
         return from(getConfigs()).filter(allowedToManageHooks()).first().isPresent();
     }
 
-    @DataBoundSetter
     public void setHookUrl(URL hookUrl) {
         if (overrideHookUrl) {
             this.hookUrl = hookUrl;
@@ -74,7 +96,6 @@ public class GitHubPluginConfig extends AbstractDescribableImpl<GitHubPluginConf
         }
     }
 
-    @DataBoundSetter
     public void setOverrideHookUrl(boolean overrideHookUrl) {
         this.overrideHookUrl = overrideHookUrl;
     }
@@ -111,60 +132,78 @@ public class GitHubPluginConfig extends AbstractDescribableImpl<GitHubPluginConf
         return Collections.singletonList(Jenkins.getInstance().getDescriptor(GitHubTokenCredentialsCreator.class));
     }
 
-    @Extension
-    public static class GitHubPluginConfigDescriptor extends Descriptor<GitHubPluginConfig> {
+    /**
+     * To avoid long class name as id in xml tag name and config file
+     */
+    @Override
+    public String getId() {
+        return GITHUB_PLUGIN_CONFIGURATION_ID;
+    }
 
-        /**
-         * Used to get current instance identity. It compared with same value when testing hook url availability
-         */
-        @Inject
-        @SuppressWarnings("unused")
-        private transient InstanceIdentity identity;
+    /**
+     * @return config file with global {@link com.thoughtworks.xstream.XStream} instance
+     * with enabled aliases in {@link Migrator#enableAliases()}
+     */
+    @Override
+    protected XmlFile getConfigFile() {
+        return new XmlFile(Jenkins.XSTREAM2, super.getConfigFile().getFile());
+    }
 
-        @Override
-        public String getDisplayName() {
-            return "GitHub Plugin Configuration";
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        try {
+            req.bindJSON(this, json);
+        } catch (Exception e) {
+            throw new FormException(
+                    format("Mailformed GitHub Plugin configuration (%s)", e.getMessage()), e, "github-configuration");
+        }
+        save();
+        return true;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "GitHub Plugin Configuration";
+    }
+
+    @SuppressWarnings("unused")
+    public FormValidation doReRegister() {
+        if (!GitHubPlugin.configuration().isManageHooks()) {
+            return FormValidation.warning("Works only when Jenkins manages hooks (one ore more creds specified)");
         }
 
-        @SuppressWarnings("unused")
-        public FormValidation doReRegister() {
-            if (!GitHubPlugin.configuration().isManageHooks()) {
-                return FormValidation.warning("Works only when Jenkins manages hooks (one ore more creds specified)");
+        List<AbstractProject> registered = GitHubWebHook.get().reRegisterAllHooks();
+
+        LOGGER.info("Called registerHooks() for {} jobs", registered.size());
+        return FormValidation.ok("Called re-register hooks for %s jobs", registered.size());
+    }
+
+    @SuppressWarnings("unused")
+    public FormValidation doCheckHookUrl(@QueryParameter String value) {
+        try {
+            HttpURLConnection con = (HttpURLConnection) new URL(value).openConnection();
+            con.setRequestMethod("POST");
+            con.setRequestProperty(GitHubWebHook.URL_VALIDATION_HEADER, "true");
+            con.connect();
+            if (con.getResponseCode() != 200) {
+                return FormValidation.error("Got %d from %s", con.getResponseCode(), value);
+            }
+            String v = con.getHeaderField(GitHubWebHook.X_INSTANCE_IDENTITY);
+            if (v == null) {
+                // people might be running clever apps that's not Jenkins, and that's OK
+                return FormValidation.warning("It doesn't look like %s is talking to any Jenkins. "
+                        + "Are you running your own app?", value);
+            }
+            RSAPublicKey key = identity.getPublic();
+            String expected = new String(Base64.encodeBase64(key.getEncoded()));
+            if (!expected.equals(v)) {
+                // if it responds but with a different ID, that's more likely wrong than correct
+                return FormValidation.error("%s is connecting to different Jenkins instances", value);
             }
 
-            List<AbstractProject> registered = GitHubWebHook.get().reRegisterAllHooks();
-
-            LOGGER.info("Called registerHooks() for {} jobs", registered.size());
-            return FormValidation.ok("Called re-register hooks for %s jobs", registered.size());
-        }
-
-        @SuppressWarnings("unused")
-        public FormValidation doCheckHookUrl(@QueryParameter String value) {
-            try {
-                HttpURLConnection con = (HttpURLConnection) new URL(value).openConnection();
-                con.setRequestMethod("POST");
-                con.setRequestProperty(GitHubWebHook.URL_VALIDATION_HEADER, "true");
-                con.connect();
-                if (con.getResponseCode() != 200) {
-                    return FormValidation.error("Got %d from %s", con.getResponseCode(), value);
-                }
-                String v = con.getHeaderField(GitHubWebHook.X_INSTANCE_IDENTITY);
-                if (v == null) {
-                    // people might be running clever apps that's not Jenkins, and that's OK
-                    return FormValidation.warning("It doesn't look like %s is talking to any Jenkins. " +
-                            "Are you running your own app?", value);
-                }
-                RSAPublicKey key = identity.getPublic();
-                String expected = new String(Base64.encodeBase64(key.getEncoded()));
-                if (!expected.equals(v)) {
-                    // if it responds but with a different ID, that's more likely wrong than correct
-                    return FormValidation.error("%s is connecting to different Jenkins instances", value);
-                }
-
-                return FormValidation.ok();
-            } catch (IOException e) {
-                return FormValidation.error(e, "Failed to test a connection to %s", value);
-            }
+            return FormValidation.ok();
+        } catch (IOException e) {
+            return FormValidation.error(e, "Failed to test a connection to %s", value);
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/github/migration/Migrator.java
+++ b/src/main/java/org/jenkinsci/plugins/github/migration/Migrator.java
@@ -6,6 +6,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.github.GitHubPlugin;
+import org.jenkinsci.plugins.github.config.GitHubPluginConfig;
 import org.jenkinsci.plugins.github.config.GitHubServerConfig;
 import org.jenkinsci.plugins.github.config.GitHubTokenCredentialsCreator;
 import org.jenkinsci.plugins.github.deprecated.Credential;
@@ -48,7 +49,7 @@ public class Migrator {
 
             descriptor.clearCredentials();
             descriptor.save();
-            GitHubPlugin.get().save();
+            GitHubPlugin.configuration().save();
         }
 
         if (descriptor.getDeprecatedHookUrl() != null) {
@@ -57,7 +58,7 @@ public class Migrator {
             GitHubPlugin.configuration().setHookUrl(descriptor.getDeprecatedHookUrl());
             descriptor.clearDeprecatedHookUrl();
             descriptor.save();
-            GitHubPlugin.get().save();
+            GitHubPlugin.configuration().save();
         }
     }
 
@@ -95,5 +96,12 @@ public class Migrator {
      */
     public static void enableCompatibilityAliases() {
         Jenkins.XSTREAM2.addCompatibilityAlias("com.cloudbees.jenkins.Credential", Credential.class);
+    }
+
+    /**
+     * Simplifies long node names in config files
+     */
+    public static void enableAliases() {
+        Jenkins.XSTREAM2.alias(GitHubPluginConfig.GITHUB_PLUGIN_CONFIGURATION_ID, GitHubPluginConfig.class);
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/github/GitHubPlugin/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/GitHubPlugin/config.groovy
@@ -1,7 +1,0 @@
-package org.jenkinsci.plugins.github.GitHubPlugin
-
-def st = namespace("jelly:stapler");
-
-instance = my.configuration
-descriptor = instance.descriptor
-st.include(from: descriptor, page: descriptor.configPage, optional: false)

--- a/src/test/java/org/jenkinsci/plugins/github/migration/MigratorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/migration/MigratorTest.java
@@ -18,6 +18,7 @@ import static java.lang.String.valueOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -76,6 +77,18 @@ public class MigratorTest {
                 both(withApiUrl(is(GITHUB_URL))).and(withCredsWithToken(TOKEN)),
                 both(withApiUrl(is(GITHUB_URL))).and(withCredsWithToken(TOKEN3))
         ));
+    }
+
+    @Test
+    @LocalData
+    public void shouldLoadDataAfterStart() throws Exception {
+        assertThat("should load 3 configs", GitHubPlugin.configuration().getConfigs(), hasSize(2));
+        assertThat("migrate custom url", GitHubPlugin.configuration().getConfigs(), hasItems(
+                withApiUrl(is(CUSTOM_GH_URL)),
+                withApiUrl(is(GITHUB_URL))
+        ));
+        assertThat("should load hook url", 
+                GitHubPlugin.configuration().getHookUrl().toString(), equalTo(HOOK_FROM_LOCAL_DATA));
     }
 
     @Test

--- a/src/test/resources/org/jenkinsci/plugins/github/migration/MigratorTest/shouldLoadDataAfterStart/com.cloudbees.jenkins.GitHubPushTrigger.xml
+++ b/src/test/resources/org/jenkinsci/plugins/github/migration/MigratorTest/shouldLoadDataAfterStart/com.cloudbees.jenkins.GitHubPushTrigger.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<com.cloudbees.jenkins.GitHubPushTrigger_-DescriptorImpl plugin="github@1.12.0"/>

--- a/src/test/resources/org/jenkinsci/plugins/github/migration/MigratorTest/shouldLoadDataAfterStart/config.xml
+++ b/src/test/resources/org/jenkinsci/plugins/github/migration/MigratorTest/shouldLoadDataAfterStart/config.xml
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudson>
+    <disabledAdministrativeMonitors/>
+    <version>1.554.1</version>
+    <numExecutors>2</numExecutors>
+    <mode>NORMAL</mode>
+    <useSecurity>true</useSecurity>
+    <authorizationStrategy class="hudson.security.AuthorizationStrategy$Unsecured"/>
+    <securityRealm class="hudson.security.SecurityRealm$None"/>
+    <disableRememberMe>false</disableRememberMe>
+    <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
+    <workspaceDir>${JENKINS_HOME}/workspace/${ITEM_FULLNAME}</workspaceDir>
+    <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+    <jdks/>
+    <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+    <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+    <clouds/>
+    <slaves/>
+    <quietPeriod>5</quietPeriod>
+    <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+    <views>
+        <hudson.model.AllView>
+            <owner class="hudson" reference="../../.."/>
+            <name>All</name>
+            <filterExecutors>false</filterExecutors>
+            <filterQueue>false</filterQueue>
+            <properties class="hudson.model.View$PropertyList"/>
+        </hudson.model.AllView>
+    </views>
+    <primaryView>All</primaryView>
+    <slaveAgentPort>0</slaveAgentPort>
+    <label></label>
+    <nodeProperties/>
+    <globalNodeProperties/>
+</hudson>

--- a/src/test/resources/org/jenkinsci/plugins/github/migration/MigratorTest/shouldLoadDataAfterStart/github-plugin-configuration.xml
+++ b/src/test/resources/org/jenkinsci/plugins/github/migration/MigratorTest/shouldLoadDataAfterStart/github-plugin-configuration.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<github-plugin-configuration plugin="github@1.12.0">
+  <configs>
+    <github-server-config>
+      <apiUrl>https://api.github.com</apiUrl>
+      <manageHooks>true</manageHooks>
+      <credentialsId>a06436b7-7862-41fd-b7dc-3fec57c81f14</credentialsId>
+    </github-server-config>
+    <github-server-config>
+      <apiUrl>http://custom.github.example.com/api/v3</apiUrl>
+      <manageHooks>true</manageHooks>
+      <credentialsId>aae86cb0-e6d2-4520-80a9-89ab80129a4f</credentialsId>
+    </github-server-config>
+  </configs>
+  <hookUrl>http://some.proxy.example.com/webhook</hookUrl>
+</github-plugin-configuration>


### PR DESCRIPTION
this simplifies resulting config classes and xml-files

new config looks like

```xml
<?xml version='1.0' encoding='UTF-8'?>
<github-plugin-configuration plugin="github@1.13.0-SNAPSHOT">
  <configs>
    <github-server-config>
      <apiUrl>https://api.github.com</apiUrl>
      <manageHooks>true</manageHooks>
      <credentialsId>a06436b7-7862-41fd-b7dc-3fec57c81f14</credentialsId>
    </github-server-config>
  </configs>
  <hookUrl>http://some.proxy.example.com/webhook</hookUrl>
</github-plugin-configuration>
```
(no migration from #65)

inspired by https://github.com/jenkinsci/envinject-plugin/pull/57

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/68)
<!-- Reviewable:end -->
