### PR TITLE
[FIXES JENKINS-30207] Don't run cleaner if github plugin not manage hooks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.coravy.hudson.plugins.github</groupId>
     <artifactId>github</artifactId>
-    <version>1.13.0</version>
+    <version>1.14.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>GitHub plugin</name>
@@ -39,7 +39,7 @@
         <connection>scm:git:git://github.com/jenkinsci/github-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/github-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/github-plugin</url>
-        <tag>github-1.13.0</tag>
+        <tag>HEAD</tag>
     </scm>
     
     <issueManagement>

--- a/src/main/java/com/cloudbees/jenkins/Cleaner.java
+++ b/src/main/java/com/cloudbees/jenkins/Cleaner.java
@@ -55,6 +55,10 @@ public class Cleaner extends PeriodicWork {
      */
     @Override
     protected void doRun() throws Exception {
+        if (!GitHubPlugin.configuration().isManageHooks()) {
+            return;
+        }
+
         URL url = GitHubPlugin.configuration().getHookUrl();
 
         List<AbstractProject> jobs = Jenkins.getInstance().getAllItems(AbstractProject.class);

--- a/src/main/java/org/jenkinsci/plugins/github/config/GitHubPluginConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/github/config/GitHubPluginConfig.java
@@ -14,6 +14,7 @@ import net.sf.json.JSONObject;
 import org.apache.commons.codec.binary.Base64;
 import org.jenkinsci.main.modules.instance_identity.InstanceIdentity;
 import org.jenkinsci.plugins.github.GitHubPlugin;
+import org.jenkinsci.plugins.github.Messages;
 import org.jenkinsci.plugins.github.internal.GHPluginConfigException;
 import org.jenkinsci.plugins.github.migration.Migrator;
 import org.kohsuke.github.GitHub;
@@ -34,6 +35,7 @@ import java.util.List;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.jenkinsci.plugins.github.config.GitHubServerConfig.allowedToManageHooks;
 import static org.jenkinsci.plugins.github.config.GitHubServerConfig.loginToGithub;
 import static org.jenkinsci.plugins.github.util.FluentIterableWrapper.from;
@@ -103,13 +105,17 @@ public class GitHubPluginConfig extends GlobalConfiguration {
 
     public URL getHookUrl() throws GHPluginConfigException {
         try {
+            String jenkinsUrl = Jenkins.getInstance().getRootUrl();
+
+            if (isEmpty(jenkinsUrl)) {
+                throw new GHPluginConfigException(Messages.global_config_url_is_empty());
+            }
+
             return hookUrl != null
                     ? hookUrl
-                    : new URL(Jenkins.getInstance().getRootUrl() + GitHubWebHook.get().getUrlName() + '/');
+                    : new URL(jenkinsUrl + GitHubWebHook.get().getUrlName() + '/');
         } catch (MalformedURLException e) {
-            throw new GHPluginConfigException(
-                    "Mailformed GH hook url in global configuration (%s)", e.getMessage()
-            );
+            throw new GHPluginConfigException(Messages.global_config_hook_url_is_mailformed(e.getMessage()));
         }
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/github/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/github/Messages.properties
@@ -1,0 +1,2 @@
+global.config.url.is.empty=Jenkins URL is empty. Set explicitly Jenkins URL in global configuration or in GitHub plugin configuration to manage hooks.
+global.config.hook.url.is.mailformed=Mailformed GH hook url in global configuration ({0})


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-30207

This helps to avoid 

```
org.jenkinsci.plugins.github.internal.GHPluginConfigException: Mailformed GH hook url in global configuration (no protocol: nullgithub-webhook/)
	at org.jenkinsci.plugins.github.config.GitHubPluginConfig.getHookUrl(GitHubPluginConfig.java:110)
	at com.cloudbees.jenkins.Cleaner.doRun(Cleaner.java:58)
	at hudson.triggers.SafeTimerTask.run(SafeTimerTask.java:51)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```

on empty jenkins installation

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/76)
<!-- Reviewable:end -->
