### PR TITLE
Don't be platform specific in checkstyle.

### DIFF
--- a/src/test/resources/checkstyle/checkstyle-config.xml
+++ b/src/test/resources/checkstyle/checkstyle-config.xml
@@ -42,7 +42,9 @@
 
     <!-- Checks whether files end with a new line.                        -->
     <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
-    <module name="NewlineAtEndOfFile"/>
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf"/>
+    </module>
 
 
 


### PR DESCRIPTION
While notable the existing checkstyle means the build is DOA on windows
that uses CRLF as a system linefeed.

Whilst this change enforces unix termination, it will break windows
clients configured with `core.autocrlf=true" but changing files can lead
to platform specific test failures (especially with resource files under
test) so EOL conversion is, in this persons eyes, evil and to be avoided at
all costs.

It would probably be worthwhile to setup .gitattributes in the root of the
repository to stop any eol conversion - but I shall leave that up to the
owners for an exercise at their leisure.