### PR TITLE
simply return on empty list of events to subscribe, without error

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github/webhook/WebhookManager.java
+++ b/src/main/java/org/jenkinsci/plugins/github/webhook/WebhookManager.java
@@ -3,9 +3,7 @@ package org.jenkinsci.plugins.github.webhook;
 import com.cloudbees.jenkins.GitHubRepositoryName;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
-
 import hudson.model.Job;
-
 import org.apache.commons.lang.Validate;
 import org.jenkinsci.plugins.github.extension.GHEventsSubscriber;
 import org.jenkinsci.plugins.github.util.misc.NullSafeFunction;
@@ -87,6 +85,12 @@ public class WebhookManager {
 
         return new Runnable() {
             public void run() {
+                if (events.isEmpty()) {
+                    LOGGER.debug("No any subscriber interested in {}, but hooks creation launched, skipping...",
+                            project.getFullName());
+                    return;
+                }
+
                 LOGGER.info("GitHub webhooks activated for job {} with {} (events: {})",
                         project.getFullName(), names, events);
 


### PR DESCRIPTION
In case of any other plugin try to register hooks without checking for subscribers. We don't want to write error to log

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/91)
<!-- Reviewable:end -->
