### PR TITLE
fix dynamic port allocation when using wiremock to mock GH

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/github/internal/GitHubClientCacheCleanupTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/internal/GitHubClientCacheCleanupTest.java
@@ -16,6 +16,7 @@ import static com.cloudbees.jenkins.GitHubWebHookFullTest.classpath;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.nio.file.Files.newDirectoryStream;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -35,7 +36,7 @@ public class GitHubClientCacheCleanupTest {
     public JenkinsRule jRule = new JenkinsRule();
 
     @Rule
-    public WireMockRule github = new WireMockRule();
+    public WireMockRule github = new WireMockRule(wireMockConfig().dynamicPort());
 
     @Before
     public void setUp() throws Exception {


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/94)
<!-- Reviewable:end -->
