### PR TITLE
Show the "GitHub" link for Workflow projects

### DIFF
--- a/src/main/java/com/coravy/hudson/plugins/github/GithubLinkAction.java
+++ b/src/main/java/com/coravy/hudson/plugins/github/GithubLinkAction.java
@@ -1,6 +1,12 @@
 package com.coravy.hudson.plugins.github;
 
+import java.util.Collection;
+import java.util.Collections;
+
+import hudson.Extension;
 import hudson.model.Action;
+import hudson.model.Job;
+import jenkins.model.TransientActionFactory;
 
 /**
  * Add the Github Logo/Icon to the sidebar.
@@ -30,4 +36,23 @@ public final class GithubLinkAction implements Action {
         return projectProperty.getProjectUrl().baseUrl();
     }
 
+    @SuppressWarnings("rawtypes")
+    @Extension
+    public static class GithubLinkActionFactory extends TransientActionFactory<Job> {
+        @Override
+        public Class<Job> type() {
+            return Job.class;
+        }
+
+        @Override
+        public Collection<? extends Action> createFor(Job j) {
+            GithubProjectProperty prop = ((Job<?, ?>) j).getProperty(GithubProjectProperty.class);
+
+            if (prop == null) {
+                return Collections.emptySet();
+            } else {
+                return Collections.singleton(new GithubLinkAction(prop));
+            }
+        }
+    }
 }

--- a/src/main/java/com/coravy/hudson/plugins/github/GithubProjectProperty.java
+++ b/src/main/java/com/coravy/hudson/plugins/github/GithubProjectProperty.java
@@ -2,7 +2,6 @@ package com.coravy.hudson.plugins.github;
 
 import com.cloudbees.jenkins.GitHubPushTrigger;
 import hudson.Extension;
-import hudson.model.Action;
 import hudson.model.Job;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
@@ -14,8 +13,6 @@ import org.kohsuke.stapler.StaplerRequest;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.logging.Logger;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -81,14 +78,6 @@ public final class GithubProjectProperty extends JobProperty<Job<?, ?>> {
     @DataBoundSetter
     public void setDisplayName(String displayName) {
         this.displayName = displayName;
-    }
-
-    @Override
-    public Collection<? extends Action> getJobActions(Job<?, ?> job) {
-        if (null != projectUrl) {
-            return Collections.singleton(new GithubLinkAction(this));
-        }
-        return Collections.emptyList();
     }
 
     /**

--- a/src/test/java/com/coravy/hudson/plugins/github/GithubLinkActionFactoryTest.java
+++ b/src/test/java/com/coravy/hudson/plugins/github/GithubLinkActionFactoryTest.java
@@ -1,0 +1,57 @@
+package com.coravy.hudson.plugins.github;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import com.coravy.hudson.plugins.github.GithubLinkAction.GithubLinkActionFactory;
+
+import hudson.model.Action;
+
+public class GithubLinkActionFactoryTest {
+    @Rule
+    public final JenkinsRule rule = new JenkinsRule();
+
+    private final GithubLinkActionFactory factory = new GithubLinkActionFactory();
+
+    private static final String PROJECT_URL = "https://github.com/jenkinsci/github-plugin/";
+
+    private WorkflowJob createExampleJob() throws IOException {
+        return rule.getInstance().createProject(WorkflowJob.class, "example");
+    }
+
+    private GithubProjectProperty createExampleProperty() {
+        return new GithubProjectProperty(PROJECT_URL);
+    }
+
+    @Test
+    public void shouldCreateGithubLinkActionForJobWithGithubProjectProperty() throws IOException {
+        final WorkflowJob job = createExampleJob();
+        final GithubProjectProperty property = createExampleProperty();
+        job.addProperty(property);
+
+        final Collection<? extends Action> actions = factory.createFor(job);
+        assertThat("factored actions list", actions.size(), is(1));
+
+        final Action action = actions.iterator().next();
+        assertThat("instance check", action, is(instanceOf(GithubLinkAction.class)));
+        assertThat("url of action", action.getUrlName(), is(property.getProjectUrlStr()));
+    }
+
+    @Test
+    public void shouldNotCreateGithubLinkActionForJobWithoutGithubProjectProperty() throws IOException {
+        final WorkflowJob job = createExampleJob();
+
+        final Collection<? extends Action> actions = factory.createFor(job);
+        assertThat("factored actions list", actions, is(empty()));
+    }
+}


### PR DESCRIPTION
This will make the "GitHub" Link show up on Workflow Jobs and other similar types (like Multibranch Workflow Jobs).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/105)
<!-- Reviewable:end -->
