### PR TITLE
[FIXED JENKINS-32666] Inject the Payload into the build

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubPayload.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubPayload.java
@@ -1,0 +1,34 @@
+package com.cloudbees.jenkins;
+
+import hudson.EnvVars;
+import hudson.model.AbstractBuild;
+import hudson.model.EnvironmentContributingAction;
+import hudson.model.InvisibleAction;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Inject the payload received by GitHub into the build through $GITHUB_PAYLOAD so it can be processed
+ * @since January 28, 2016
+ * @version 1.17.1
+ */
+public class GitHubPayload extends InvisibleAction implements EnvironmentContributingAction {
+    private final String payload;
+
+    public GitHubPayload(String payload) {
+        this.payload = payload;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    @Override
+    public void buildEnvVars(AbstractBuild<?, ?> abstractBuild, EnvVars envVars) {
+        LOGGER.log(Level.FINEST, "Injecting GITHUB_PAYLOAD: {0}", payload);
+        envVars.put("GITHUB_PAYLOAD", payload);
+    }
+
+    private static final Logger LOGGER = Logger.getLogger(GitHubPayload.class.getName());
+}

--- a/src/main/java/com/cloudbees/jenkins/GitHubTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubTrigger.java
@@ -22,7 +22,13 @@ public interface GitHubTrigger {
     void onPost();
 
     // TODO: document me
+    @Deprecated
     void onPost(String triggeredByUser);
+
+    /**
+     * Called when a POST is made
+     */
+    void onPost(String triggeredByUser, String payload);
 
     /**
      * Obtains the list of the repositories that this trigger is looking at.

--- a/src/main/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventSubscriber.java
+++ b/src/main/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventSubscriber.java
@@ -60,7 +60,7 @@ public class DefaultPushGHEventSubscriber extends GHEventsSubscriber {
      * @param payload payload of gh-event. Never blank
      */
     @Override
-    protected void onEvent(GHEvent event, String payload) {
+    protected void onEvent(GHEvent event, final String payload) {
         JSONObject json = JSONObject.fromObject(payload);
         String repoUrl = json.getJSONObject("repository").getString("url");
         final String pusherName = json.getJSONObject("pusher").getString("name");
@@ -81,7 +81,7 @@ public class DefaultPushGHEventSubscriber extends GHEventsSubscriber {
                             LOGGER.debug("Considering to poke {}", job.getFullDisplayName());
                             if (GitHubRepositoryNameContributor.parseAssociatedNames(job).contains(changedRepository)) {
                                 LOGGER.info("Poked {}", job.getFullDisplayName());
-                                trigger.onPost(pusherName);
+                                trigger.onPost(pusherName, payload);
                             } else {
                                 LOGGER.debug("Skipped {} because it doesn't have a matching repository.",
                                         job.getFullDisplayName());

--- a/src/test/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventListenerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventListenerTest.java
@@ -53,7 +53,7 @@ public class DefaultPushGHEventListenerTest {
         new DefaultPushGHEventSubscriber()
                 .onEvent(GHEvent.PUSH, classpath("payloads/push.json"));
 
-        verify(trigger).onPost(TRIGGERED_BY_USER_FROM_RESOURCE);
+        verify(trigger).onPost(TRIGGERED_BY_USER_FROM_RESOURCE, classpath("payloads/push.json"));
     }
 
     @Test
@@ -70,7 +70,7 @@ public class DefaultPushGHEventListenerTest {
         new DefaultPushGHEventSubscriber()
                 .onEvent(GHEvent.PUSH, classpath("payloads/push.json"));
 
-        verify(trigger).onPost(TRIGGERED_BY_USER_FROM_RESOURCE);
+        verify(trigger).onPost(TRIGGERED_BY_USER_FROM_RESOURCE, classpath("payloads/push.json"));
     }
 
     @Test
@@ -85,6 +85,6 @@ public class DefaultPushGHEventListenerTest {
         new DefaultPushGHEventSubscriber()
                 .onEvent(GHEvent.PUSH, classpath("payloads/push.json"));
 
-        verify(trigger, never()).onPost(TRIGGERED_BY_USER_FROM_RESOURCE);
+        verify(trigger, never()).onPost(TRIGGERED_BY_USER_FROM_RESOURCE, classpath("payloads/push.json"));
     }
 }


### PR DESCRIPTION
It might be interesting to inject the GitHub payload received into the build so it can be treated at build level.

The blog below explains what is the interest of injecting this information at build level.
* http://chloky.com/github-pull-req-webhook/
* http://chloky.com/github-json-payload-in-jenkins/

https://issues.jenkins-ci.org/browse/JENKINS-32666

@reviewbybees

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/108)
<!-- Reviewable:end -->
