### PR TITLE
Fixed incorrect proxy configuration of GitHubLoginFunction

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github/internal/GitHubLoginFunction.java
+++ b/src/main/java/org/jenkinsci/plugins/github/internal/GitHubLoginFunction.java
@@ -20,6 +20,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
 
@@ -90,7 +91,11 @@ public class GitHubLoginFunction extends NullSafeFunction<GitHubServerConfig, Gi
         if (jenkins.proxy == null) {
             return Proxy.NO_PROXY;
         } else {
-            return jenkins.proxy.createProxy(apiUrl);
+            try {
+                return jenkins.proxy.createProxy(new URL(apiUrl).getHost());
+            } catch (MalformedURLException e) {
+                return jenkins.proxy.createProxy(apiUrl);
+            }
         }
     }
 


### PR DESCRIPTION
The [Jenkins ProxyConfiguration class](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/ProxyConfiguration.java) expects only the hostname (e.g. `git.example.com` vs `https://git.example.com/api/`) as a method parameter to `createProxy`, but the existing code gives it the whole URL.
As a result of this, the validation of no proxy hosts is not correct. In most cases this is not a problem, but it is for some enterprise GitHub instances.

The handling of the possible MalformedURLException might not be the most suitable, it may needs to be replaced.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/109)
<!-- Reviewable:end -->
