### PR TITLE
Handle ssh:// URLs that doesn't contain git@

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubRepositoryName.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubRepositoryName.java
@@ -49,7 +49,7 @@ public class GitHubRepositoryName {
             Pattern.compile("https?://[^/]+@([^/]+)/([^/]+)/([^/]+)\\.git"),
             Pattern.compile("https?://([^/]+)/([^/]+)/([^/]+)\\.git"),
             Pattern.compile("git://([^/]+)/([^/]+)/([^/]+)\\.git"),
-            Pattern.compile("ssh://git@([^/]+)/([^/]+)/([^/]+)\\.git"),
+            Pattern.compile("ssh://(?:git@)?([^/]+)/([^/]+)/([^/]+)\\.git"),
             /**
              * The second set of patterns extract the host, owner and repository names
              * from all other URLs. Note that these patterns must be processed *after*
@@ -60,7 +60,7 @@ public class GitHubRepositoryName {
             Pattern.compile("https?://[^/]+@([^/]+)/([^/]+)/([^/]+)/?"),
             Pattern.compile("https?://([^/]+)/([^/]+)/([^/]+)/?"),
             Pattern.compile("git://([^/]+)/([^/]+)/([^/]+)/?"),
-            Pattern.compile("ssh://git@([^/]+)/([^/]+)/([^/]+)/?")
+            Pattern.compile("ssh://(?:git@)?([^/]+)/([^/]+)/([^/]+)/?")
     };
 
     /**

--- a/src/test/java/com/coravy/hudson/plugins/github/GitHubRepositoryNameTest.java
+++ b/src/test/java/com/coravy/hudson/plugins/github/GitHubRepositoryNameTest.java
@@ -49,6 +49,12 @@ public class GitHubRepositoryNameTest {
             "https://github.com/jenkinsci/jenkins.git, github.com, jenkinsci, jenkins",
             "https://github.com/jenkinsci/jenkins, github.com, jenkinsci, jenkins",
             "https://github.com/jenkinsci/jenkins/, github.com, jenkinsci, jenkins",
+            "ssh://git@github.com/jenkinsci/jenkins.git, github.com, jenkinsci, jenkins",
+            "ssh://git@github.com/jenkinsci/jenkins, github.com, jenkinsci, jenkins",
+            "ssh://git@github.com/jenkinsci/jenkins/, github.com, jenkinsci, jenkins",
+            "ssh://github.com/jenkinsci/jenkins.git, github.com, jenkinsci, jenkins",
+            "ssh://github.com/jenkinsci/jenkins, github.com, jenkinsci, jenkins",
+            "ssh://github.com/jenkinsci/jenkins/, github.com, jenkinsci, jenkins",
     })
     public void githubFullRepo(String url, String host, String user, String repo) {
         assertThat(url, repo(allOf(


### PR DESCRIPTION
It is possible to specify and use github.com URLs as
`ssh://github.com/username/repo`, as credentials used
for SCM configuration usually include username.
This change would allow to properly parse such URLs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/110)
<!-- Reviewable:end -->
