### PR TITLE
Don't let the build fail if the commit doesn't exist in upstream

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubCommitNotifier.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubCommitNotifier.java
@@ -14,7 +14,6 @@ import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
 import hudson.util.ListBoxModel;
 import jenkins.tasks.SimpleBuildStep;
-
 import org.eclipse.jgit.lib.ObjectId;
 import org.jenkinsci.plugins.github.common.ExpandableMessage;
 import org.jenkinsci.plugins.github.util.BuildDataHelper;
@@ -55,7 +54,7 @@ public class GitHubCommitNotifier extends Notifier implements SimpleBuildStep {
     private final String resultOnFailure;
     private static final Result[] SUPPORTED_RESULTS = {FAILURE, UNSTABLE, SUCCESS};
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(GitHubWebHook.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(GitHubCommitNotifier.class);
 
     @Restricted(NoExternalUse.class)
     public GitHubCommitNotifier() {
@@ -109,9 +108,9 @@ public class GitHubCommitNotifier extends Notifier implements SimpleBuildStep {
 
     @Override
     public void perform(Run<?, ?> build,
-                           FilePath ws,
-                           Launcher launcher,
-                           TaskListener listener) throws InterruptedException, IOException {
+                        FilePath ws,
+                        Launcher launcher,
+                        TaskListener listener) throws InterruptedException, IOException {
         try {
             updateCommitStatus(build, listener);
         } catch (IOException error) {
@@ -155,8 +154,8 @@ public class GitHubCommitNotifier extends Notifier implements SimpleBuildStep {
                     // doesn't exist in the upstream. Don't let the build fail
                     // TODO: ideally we'd like other plugins to designate a commit to put the status update to
                     LOGGER.debug("Failed to update commit status", e);
-                    listener.getLogger().println("Commit doesn't exist in "
-                            + repository.getFullName() + ". Status is not set");
+                    listener.getLogger()
+                            .format("Commit doesn't exist in %s. Status is not set%n", repository.getFullName());
                 }
             }
         }

--- a/src/main/java/com/cloudbees/jenkins/GitHubCommitNotifier.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubCommitNotifier.java
@@ -24,8 +24,11 @@ import org.kohsuke.github.GHCommitState;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import static com.cloudbees.jenkins.Messages.GitHubCommitNotifier_DisplayName;
@@ -51,6 +54,8 @@ public class GitHubCommitNotifier extends Notifier implements SimpleBuildStep {
 
     private final String resultOnFailure;
     private static final Result[] SUPPORTED_RESULTS = {FAILURE, UNSTABLE, SUCCESS};
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GitHubWebHook.class);
 
     @Restricted(NoExternalUse.class)
     public GitHubCommitNotifier() {
@@ -139,11 +144,20 @@ public class GitHubCommitNotifier extends Notifier implements SimpleBuildStep {
                         GitHubCommitNotifier_SettingCommitStatus(repository.getHtmlUrl() + "/commit/" + sha1)
                 );
 
-                repository.createCommitStatus(
-                        sha1, status.getState(), build.getAbsoluteUrl(),
-                        message,
-                        contextName
-                );
+                try {
+                    repository.createCommitStatus(
+                            sha1, status.getState(), build.getAbsoluteUrl(),
+                            message,
+                            contextName
+                    );
+                } catch (FileNotFoundException e) {
+                    // PR builds and other merge activities can create a merge commit that
+                    // doesn't exist in the upstream. Don't let the build fail
+                    // TODO: ideally we'd like other plugins to designate a commit to put the status update to
+                    LOGGER.debug("Failed to update commit status", e);
+                    listener.getLogger().println("Commit doesn't exist in "
+                            + repository.getFullName() + ". Status is not set");
+                }
             }
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/github/util/BuildDataHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/github/util/BuildDataHelper.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.github.util;
 
 import hudson.model.Run;
 import hudson.plugins.git.Revision;
+import hudson.plugins.git.util.Build;
 import hudson.plugins.git.util.BuildData;
 import org.eclipse.jgit.lib.ObjectId;
 
@@ -32,11 +33,20 @@ public final class BuildDataHelper {
         if (buildData == null) {
             throw new IOException(Messages.BuildDataHelper_NoBuildDataError());
         }
-        final Revision lastBuildRevision = buildData.getLastBuiltRevision();
-        final ObjectId sha1 = lastBuildRevision != null ? lastBuildRevision.getSha1() : null;
-        if (sha1 == null) { // Nowhere to report => fail the build
-            throw new IOException(Messages.BuildDataHelper_NoLastRevisionError());
+
+        // buildData?.lastBuild?.marked and fall back to .revision with null check everywhere to be defensive
+        Build b = buildData.lastBuild;
+        if (b != null) {
+            Revision r = b.marked;
+            if (r == null) {
+                r = b.revision;
+            }
+            if (r != null) {
+                return r.getSha1();
+            }
         }
-        return sha1;
+
+        // Nowhere to report => fail the build
+        throw new IOException(Messages.BuildDataHelper_NoLastRevisionError());
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/GitHubCommitNotifierTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GitHubCommitNotifierTest.java
@@ -73,6 +73,7 @@ public class GitHubCommitNotifierTest {
         @Override
         protected void before() throws Throwable {
             when(data.getLastBuiltRevision()).thenReturn(rev);
+            data.lastBuild = new hudson.plugins.git.util.Build(rev,rev,0,Result.SUCCESS);
             when(rev.getSha1()).thenReturn(ObjectId.fromString(SOME_SHA));
         }
     };

--- a/src/test/java/com/cloudbees/jenkins/GitHubCommitNotifierTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GitHubCommitNotifierTest.java
@@ -34,6 +34,8 @@ import static com.cloudbees.jenkins.GitHubSetCommitStatusBuilderTest.SOME_SHA;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.jenkinsci.plugins.github.util.Messages.BuildDataHelper_NoBuildDataError;
+import static org.jenkinsci.plugins.github.util.Messages.BuildDataHelper_NoLastRevisionError;
 import static org.mockito.Mockito.when;
 
 /**
@@ -73,7 +75,7 @@ public class GitHubCommitNotifierTest {
         @Override
         protected void before() throws Throwable {
             when(data.getLastBuiltRevision()).thenReturn(rev);
-            data.lastBuild = new hudson.plugins.git.util.Build(rev,rev,0,Result.SUCCESS);
+            data.lastBuild = new hudson.plugins.git.util.Build(rev, rev, 0, Result.SUCCESS);
             when(rev.getSha1()).thenReturn(ObjectId.fromString(SOME_SHA));
         }
     };
@@ -85,7 +87,7 @@ public class GitHubCommitNotifierTest {
         prj.getPublishersList().add(new GitHubCommitNotifier());
         Build b = prj.scheduleBuild2(0).get();
         jRule.assertBuildStatus(Result.FAILURE, b);
-        jRule.assertLogContains(org.jenkinsci.plugins.github.util.Messages.BuildDataHelper_NoBuildDataError(), b);
+        jRule.assertLogContains(BuildDataHelper_NoBuildDataError(), b);
     }
 
     @Test
@@ -96,7 +98,7 @@ public class GitHubCommitNotifierTest {
         prj.getPublishersList().add(new GitHubCommitNotifier());
         Build b = prj.scheduleBuild2(0).get();
         jRule.assertBuildStatus(Result.FAILURE, b);
-        jRule.assertLogContains(org.jenkinsci.plugins.github.util.Messages.BuildDataHelper_NoLastRevisionError(), b);
+        jRule.assertLogContains(BuildDataHelper_NoLastRevisionError(), b);
     }
 
     @Test

--- a/src/test/java/com/cloudbees/jenkins/GitHubSetCommitStatusBuilderTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GitHubSetCommitStatusBuilderTest.java
@@ -77,6 +77,7 @@ public class GitHubSetCommitStatusBuilderTest {
         @Override
         protected void before() throws Throwable {
             when(data.getLastBuiltRevision()).thenReturn(rev);
+            data.lastBuild = new hudson.plugins.git.util.Build(rev,rev,0,Result.SUCCESS);
             when(rev.getSha1()).thenReturn(ObjectId.fromString(SOME_SHA));
         }
     };

--- a/src/test/java/com/cloudbees/jenkins/GitHubSetCommitStatusBuilderTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GitHubSetCommitStatusBuilderTest.java
@@ -57,11 +57,11 @@ public class GitHubSetCommitStatusBuilderTest {
 
     @Inject
     public GitHubPluginConfig config;
-    
+
     public JenkinsRule jRule = new JenkinsRule();
 
     @Rule
-    public RuleChain chain = RuleChain.outerRule(jRule).around(new InjectJenkinsMembersRule(jRule, this)); 
+    public RuleChain chain = RuleChain.outerRule(jRule).around(new InjectJenkinsMembersRule(jRule, this));
 
     @Rule
     public GHMockRule github = new GHMockRule(
@@ -77,7 +77,7 @@ public class GitHubSetCommitStatusBuilderTest {
         @Override
         protected void before() throws Throwable {
             when(data.getLastBuiltRevision()).thenReturn(rev);
-            data.lastBuild = new hudson.plugins.git.util.Build(rev,rev,0,Result.SUCCESS);
+            data.lastBuild = new hudson.plugins.git.util.Build(rev, rev, 0, Result.SUCCESS);
             when(rev.getSha1()).thenReturn(ObjectId.fromString(SOME_SHA));
         }
     };


### PR DESCRIPTION
PR builds and other merge activities can create a new tip of the repository that's not in the github repository. This plugin causes the build to fail in such a case today, which is undesirable. We'd rather just have the build to succeed without a commit status.

This is the stack trace you get when that happens:

````
ERROR: Step ‘Set build status on GitHub commit’ aborted due to exception: 
java.io.FileNotFoundException: {"message":"No commit found for SHA: bb077596591672c8348ace0f8ddb2a13df2e0892","documentation_url":"https://developer.github.com/v3/repos/statuses/"}
	at org.kohsuke.github.Requester.handleApiError(Requester.java:527)
	at org.kohsuke.github.Requester._to(Requester.java:257)
	at org.kohsuke.github.Requester.to(Requester.java:203)
	at org.kohsuke.github.GHRepository.createCommitStatus(GHRepository.java:854)
	at com.cloudbees.jenkins.GitHubCommitNotifier.updateCommitStatus(GitHubCommitNotifier.java:142)
	at com.cloudbees.jenkins.GitHubCommitNotifier.perform(GitHubCommitNotifier.java:111)
	at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:75)
	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:795)
	at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:736)
	at hudson.model.Build$BuildExecution.post2(Build.java:185)
	at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:681)
	at hudson.model.Run.execute(Run.java:1766)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:98)
	at hudson.model.Executor.run(Executor.java:408)
Caused by: java.io.FileNotFoundException: https://api.github.com/repos/cloudbees/blueocean/statuses/bb077596591672c8348ace0f8ddb2a13df2e0892
	at com.squareup.okhttp.internal.huc.HttpURLConnectionImpl.getInputStream(HttpURLConnectionImpl.java:240)
	at com.squareup.okhttp.internal.huc.DelegatingHttpsURLConnection.getInputStream(DelegatingHttpsURLConnection.java:210)
	at com.squareup.okhttp.internal.huc.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:25)
	at org.kohsuke.github.Requester.parse(Requester.java:483)
	at org.kohsuke.github.Requester._to(Requester.java:236)
	... 14 more
````

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/111)
<!-- Reviewable:end -->
