### PR TITLE
[JENKINS-33228] Misc global config page improvements

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github/config/GitHubPluginConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/github/config/GitHubPluginConfig.java
@@ -171,7 +171,7 @@ public class GitHubPluginConfig extends GlobalConfiguration {
 
     @Override
     public String getDisplayName() {
-        return "GitHub Plugin Configuration";
+        return "GitHub Configuration";
     }
 
     @SuppressWarnings("unused")

--- a/src/main/java/org/jenkinsci/plugins/github/config/GitHubPluginConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/github/config/GitHubPluginConfig.java
@@ -171,7 +171,7 @@ public class GitHubPluginConfig extends GlobalConfiguration {
 
     @Override
     public String getDisplayName() {
-        return "GitHub Configuration";
+        return "GitHub";
     }
 
     @SuppressWarnings("unused")

--- a/src/main/java/org/jenkinsci/plugins/github/config/GitHubServerConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/github/config/GitHubServerConfig.java
@@ -261,7 +261,7 @@ public class GitHubServerConfig extends AbstractDescribableImpl<GitHubServerConf
 
         @Override
         public String getDisplayName() {
-            return "GitHub Server Config";
+            return "GitHub Server";
         }
 
         @SuppressWarnings("unused")

--- a/src/main/java/org/jenkinsci/plugins/github/config/GitHubServerConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/github/config/GitHubServerConfig.java
@@ -83,11 +83,6 @@ public class GitHubServerConfig extends AbstractDescribableImpl<GitHubServerConf
     private int clientCacheSize = DEFAULT_CLIENT_CACHE_SIZE_MB;
 
     /**
-     * only to set to default apiUrl when uncheck. Can be removed if optional block can nullify value if unchecked
-     */
-    private transient boolean customApiUrl;
-
-    /**
      * To avoid creation of new one on every login with this config
      */
     private transient GitHub cachedClient;
@@ -98,28 +93,26 @@ public class GitHubServerConfig extends AbstractDescribableImpl<GitHubServerConf
     }
 
     /**
-     * {@link #customApiUrl} field should be defined earlier. Because of we get full content of optional block,
-     * even if it already unchecked. So if we want to return api url to default value - custom value should affect
+     * Set the API endpoint.
      *
      * @param apiUrl custom url if GH. Default value will be used in case of custom is unchecked or value is blank
      */
     @DataBoundSetter
     public void setApiUrl(String apiUrl) {
-        if (customApiUrl) {
-            this.apiUrl = defaultIfBlank(apiUrl, GITHUB_URL);
-        } else {
-            this.apiUrl = GITHUB_URL;
-        }
+        this.apiUrl = defaultIfBlank(apiUrl, GITHUB_URL);
     }
 
     /**
-     * Should be called before {@link #setApiUrl(String)}
      *
      * @param customApiUrl true if optional block "Custom GH Api Url" checked in UI
+     * @deprecated
+     *      just set {@link #setApiUrl(String)}
      */
     @DataBoundSetter
     public void setCustomApiUrl(boolean customApiUrl) {
-        this.customApiUrl = customApiUrl;
+        if (!customApiUrl) {
+            this.apiUrl = GITHUB_URL;
+        }
     }
 
     /**
@@ -138,6 +131,7 @@ public class GitHubServerConfig extends AbstractDescribableImpl<GitHubServerConf
 
     /**
      * @see #isUrlCustom(String)
+     * @deprecated
      */
     @Restricted(NoExternalUse.class)
     public boolean isCustomApiUrl() {
@@ -291,7 +285,6 @@ public class GitHubServerConfig extends AbstractDescribableImpl<GitHubServerConf
                 @QueryParameter Integer clientCacheSize) throws IOException {
 
             GitHubServerConfig config = new GitHubServerConfig(credentialsId);
-            config.setCustomApiUrl(isUrlCustom(apiUrl));
             config.setApiUrl(apiUrl);
             config.setClientCacheSize(clientCacheSize);
             GitHub gitHub = new GitHubLoginFunction().apply(config);

--- a/src/main/java/org/jenkinsci/plugins/github/config/GitHubServerConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/github/config/GitHubServerConfig.java
@@ -103,19 +103,6 @@ public class GitHubServerConfig extends AbstractDescribableImpl<GitHubServerConf
     }
 
     /**
-     *
-     * @param customApiUrl true if optional block "Custom GH Api Url" checked in UI
-     * @deprecated
-     *      just set {@link #setApiUrl(String)}
-     */
-    @DataBoundSetter
-    public void setCustomApiUrl(boolean customApiUrl) {
-        if (!customApiUrl) {
-            this.apiUrl = GITHUB_URL;
-        }
-    }
-
-    /**
      * This server config will be used to manage GH Hooks if true
      *
      * @param manageHooks false to ignore this config on hook auto-management
@@ -127,15 +114,6 @@ public class GitHubServerConfig extends AbstractDescribableImpl<GitHubServerConf
 
     public String getApiUrl() {
         return apiUrl;
-    }
-
-    /**
-     * @see #isUrlCustom(String)
-     * @deprecated
-     */
-    @Restricted(NoExternalUse.class)
-    public boolean isCustomApiUrl() {
-        return isUrlCustom(apiUrl);
     }
 
     public boolean isManageHooks() {

--- a/src/main/java/org/jenkinsci/plugins/github/config/GitHubServerConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/github/config/GitHubServerConfig.java
@@ -19,8 +19,6 @@ import org.jenkinsci.plugins.github.util.misc.NullSafeFunction;
 import org.jenkinsci.plugins.github.util.misc.NullSafePredicate;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;

--- a/src/main/java/org/jenkinsci/plugins/github/config/GitHubServerConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/github/config/GitHubServerConfig.java
@@ -281,12 +281,11 @@ public class GitHubServerConfig extends AbstractDescribableImpl<GitHubServerConf
         @SuppressWarnings("unused")
         public FormValidation doVerifyCredentials(
                 @QueryParameter String apiUrl,
-                @QueryParameter String credentialsId,
-                @QueryParameter Integer clientCacheSize) throws IOException {
+                @QueryParameter String credentialsId) throws IOException {
 
             GitHubServerConfig config = new GitHubServerConfig(credentialsId);
             config.setApiUrl(apiUrl);
-            config.setClientCacheSize(clientCacheSize);
+            config.setClientCacheSize(0);
             GitHub gitHub = new GitHubLoginFunction().apply(config);
 
             try {

--- a/src/main/java/org/jenkinsci/plugins/github/migration/Migrator.java
+++ b/src/main/java/org/jenkinsci/plugins/github/migration/Migrator.java
@@ -16,7 +16,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 
 import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
-import static org.jenkinsci.plugins.github.config.GitHubServerConfig.isUrlCustom;
 import static org.jenkinsci.plugins.github.util.FluentIterableWrapper.from;
 
 /**
@@ -83,7 +82,6 @@ public class Migrator {
                 );
 
                 GitHubServerConfig gitHubServerConfig = new GitHubServerConfig(credentials.getId());
-                gitHubServerConfig.setCustomApiUrl(isUrlCustom(input.getApiUrl()));
                 gitHubServerConfig.setApiUrl(input.getApiUrl());
 
                 return gitHubServerConfig;

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/config.groovy
@@ -10,7 +10,8 @@ f.section(title: descriptor.displayName) {
         
         f.repeatableHeteroProperty(
                 field: "configs",
-                hasHeader: "true")
+                hasHeader: "true",
+                addCaption: _("Add GitHub Server"))
     }
 
     f.advanced() {

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/config.groovy
@@ -6,7 +6,6 @@ def f = namespace(lib.FormTagLib);
 
 f.section(title: descriptor.displayName) {
     f.entry(title: _("GitHub Servers"),
-            description: _("List of GitHub Servers to manage hooks, set commit statuses etc."),
             help: descriptor.getHelpFile()) {
         
         f.repeatableHeteroProperty(

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/config.groovy
@@ -5,7 +5,7 @@ import com.cloudbees.jenkins.GitHubPushTrigger
 def f = namespace(lib.FormTagLib);
 
 f.section(title: descriptor.displayName) {
-    f.entry(title: _("Servers configs with credentials to manage GitHub integrations"),
+    f.entry(title: _("GitHub Servers"),
             description: _("List of GitHub Servers to manage hooks, set commit statuses etc."),
             help: descriptor.getHelpFile()) {
         

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/config.groovy
@@ -10,9 +10,7 @@ f.section(title: descriptor.displayName) {
         
         f.repeatableHeteroProperty(
                 field: "configs",
-                hasHeader: "true",
-                addCaption: _("Add GitHub Server Config"),
-                deleteCaption: _("Delete GitHub Server Config"))
+                hasHeader: "true")
     }
 
     f.advanced() {

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/config.groovy
@@ -6,22 +6,12 @@ def f = namespace(lib.FormTagLib);
 def c = namespace(lib.CredentialsTagLib)
 
 
-f.entry(title: _("Manage hooks"), field: "manageHooks") {
-    f.checkbox(default: true)
-}
-
-f.entry(title: _("Credentials"), field: "credentialsId") {
-    c.select()
-}
-
 f.entry(title: _("API URL"), field: "apiUrl") {
     f.textbox(default: GitHubServerConfig.GITHUB_URL)
 }
 
-f.advanced() {
-    f.entry(title: _("GitHub client cache size (MB)"), field: "clientCacheSize") {
-        f.textbox(default: GitHubServerConfig.DEFAULT_CLIENT_CACHE_SIZE_MB)
-    }
+f.entry(title: _("Credentials"), field: "credentialsId") {
+    c.select()
 }
 
 f.block() {
@@ -33,3 +23,13 @@ f.block() {
     )
 }
 
+
+f.entry(title: _("Manage hooks"), field: "manageHooks") {
+    f.checkbox(default: true)
+}
+
+f.advanced() {
+    f.entry(title: _("GitHub client cache size (MB)"), field: "clientCacheSize") {
+        f.textbox(default: GitHubServerConfig.DEFAULT_CLIENT_CACHE_SIZE_MB)
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/config.groovy
@@ -14,13 +14,8 @@ f.entry(title: _("Credentials"), field: "credentialsId") {
     c.select()
 }
 
-f.optionalBlock(title: _("Custom GitHub API URL"),
-        inline: true,
-        field: "customApiUrl",
-        checked: instance?.customApiUrl) {
-    f.entry(title: _("GitHub API URL"), field: "apiUrl") {
-        f.textbox(default: GitHubServerConfig.GITHUB_URL)
-    }
+f.entry(title: _("API URL"), field: "apiUrl") {
+    f.textbox(default: GitHubServerConfig.GITHUB_URL)
 }
 
 f.advanced() {

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/config.groovy
@@ -19,7 +19,7 @@ f.block() {
             title: _("Test connection"),
             progress: _("Testing..."),
             method: "verifyCredentials",
-            with: "apiUrl,credentialsId,clientCacheSize"
+            with: "apiUrl,credentialsId"
     )
 }
 

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/config.groovy
@@ -16,8 +16,8 @@ f.entry(title: _("Credentials"), field: "credentialsId") {
 
 f.block() {
     f.validateButton(
-            title: _("Verify credentials"),
-            progress: _("Verifying..."),
+            title: _("Test connection"),
+            progress: _("Testing..."),
             method: "verifyCredentials",
             with: "apiUrl,credentialsId,clientCacheSize"
     )

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/help-apiUrl.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/help-apiUrl.html
@@ -1,0 +1,6 @@
+<div>
+    If you use GitHub Enterprise, specify the API end point here
+    (e.g., <code>https://ghe.acme.com/api/v3/</code>).
+    The default value of <code>https://api.github.com</code>
+    refers to the public github.com instance.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/help-apiUrl.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/help-apiUrl.html
@@ -1,6 +1,9 @@
 <div>
-    If you use GitHub Enterprise, specify the API end point here
+    API endpoint of a GitHub server.
+
+    To use public github.com, leave this field
+    to the default value of <code>https://api.github.com</code>.
+
+    Otherwise if you use GitHub Enterprise, specify its API endpoint here
     (e.g., <code>https://ghe.acme.com/api/v3/</code>).
-    The default value of <code>https://api.github.com</code>
-    refers to the public github.com instance.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/help-clientCacheSize.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/help-clientCacheSize.html
@@ -1,7 +1,11 @@
 <div>
-    Cache size in MB used by GitHub client. This can speed up fetching data form GH and reduce rate limits consuming.<br/>
-    GH + okHttp do all work for results reliability 
-    (<a href="https://developer.github.com/v3/#conditional-requests">Conditional-requests in GitHub documentation</a>)<br/>
-    
-    Set <b>0</b> to disable this feature
+    <p>
+        Jenkins will use this much space in <tt>$JENKINS_HOME</tt> to cache data retrieved from GitHub API calls.
+        A cache will help improve the performance by avoiding unnecessary data transfer, and by doing so it also
+        makes it less likely to hit <a href="https://developer.github.com/v3/#rate-limiting">API rate limit</a>
+        by the use of (<a href="https://developer.github.com/v3/#conditional-requests">conditional GET</a> calls.
+    </p>
+    <p>
+        In an unlikely event that cache is causing a problem, set this to <b>0</b> to disable cache altogether.
+    </p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/help-clientCacheSize.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/help-clientCacheSize.html
@@ -1,9 +1,10 @@
 <div>
     <p>
-        Jenkins will use this much space in <tt>$JENKINS_HOME</tt> to cache data retrieved from GitHub API calls.
+        Jenkins will use this much space, measured in megabytes,
+        in <tt>$JENKINS_HOME</tt> to cache data retrieved from GitHub API calls.
         A cache will help improve the performance by avoiding unnecessary data transfer, and by doing so it also
         makes it less likely to hit <a href="https://developer.github.com/v3/#rate-limiting">API rate limit</a>
-        by the use of (<a href="https://developer.github.com/v3/#conditional-requests">conditional GET</a> calls.
+        (by the use of <a href="https://developer.github.com/v3/#conditional-requests">conditional GET</a> calls.)
     </p>
     <p>
         In an unlikely event that cache is causing a problem, set this to <b>0</b> to disable cache altogether.

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/help-customApiUrl.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/help-customApiUrl.html
@@ -1,5 +1,0 @@
-<div>
-    If you use GitHub Enterprise you may specify the API end point here
-    (e.g., <code>https://ghe.acme.com/api/v3/</code>). Otherwise, the public
-    <code>https://api.github.com/</code> endpoint will be assumed.
-</div>

--- a/src/test/java/org/jenkinsci/plugins/github/config/GitHubServerConfigTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/config/GitHubServerConfigTest.java
@@ -59,7 +59,6 @@ public class GitHubServerConfigTest {
     @Test
     public void shouldNotMatchNonDefaultConfigWithGHDefaultHost() throws Exception {
         GitHubServerConfig input = new GitHubServerConfig("");
-        input.setCustomApiUrl(true);
         input.setApiUrl(CUSTOM_GH_SERVER);
         assertThat(withHost(DEFAULT_GH_API_HOST).apply(input), is(false));
     }

--- a/src/test/java/org/jenkinsci/plugins/github/internal/GitHubClientCacheCleanupTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/internal/GitHubClientCacheCleanupTest.java
@@ -6,6 +6,7 @@ import org.jenkinsci.plugins.github.test.GHMockRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.kohsuke.github.GitHub;
 
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
@@ -101,7 +102,10 @@ public class GitHubClientCacheCleanupTest {
     }
 
     private void makeCachedRequestWithCredsId(String credsId) throws IOException {
-        jRule.getInstance().getDescriptorByType(GitHubServerConfig.DescriptorImpl.class)
-                .doVerifyCredentials(github.serverConfig().getApiUrl(), credsId, 1);
+        GitHubServerConfig config = new GitHubServerConfig(credsId);
+        config.setApiUrl(github.serverConfig().getApiUrl());
+        config.setClientCacheSize(1);
+        GitHub gitHub = new GitHubLoginFunction().apply(config);
+        gitHub.getMyself();
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/github/internal/GitHubClientCacheCleanupTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/internal/GitHubClientCacheCleanupTest.java
@@ -105,7 +105,7 @@ public class GitHubClientCacheCleanupTest {
         GitHubServerConfig config = new GitHubServerConfig(credsId);
         config.setApiUrl(github.serverConfig().getApiUrl());
         config.setClientCacheSize(1);
-        GitHub gitHub = new GitHubLoginFunction().apply(config);
+        GitHub gitHub = GitHubServerConfig.loginToGithub().apply(config);
         gitHub.getMyself();
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/github/internal/GitHubClientCacheCleanupTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/internal/GitHubClientCacheCleanupTest.java
@@ -73,7 +73,6 @@ public class GitHubClientCacheCleanupTest {
         makeCachedRequestWithCredsId(CHANGED_CREDS_ID);
 
         GitHubServerConfig config = new GitHubServerConfig(CHANGED_CREDS_ID);
-        config.setCustomApiUrl(true);
         config.setApiUrl(github.serverConfig().getApiUrl());
         config.setClientCacheSize(1);
 
@@ -87,7 +86,6 @@ public class GitHubClientCacheCleanupTest {
         makeCachedRequestWithCredsId(CHANGED_CREDS_ID);
 
         GitHubServerConfig config = new GitHubServerConfig(CHANGED_CREDS_ID);
-        config.setCustomApiUrl(true);
         config.setApiUrl(github.serverConfig().getApiUrl());
         config.setClientCacheSize(0);
 

--- a/src/test/java/org/jenkinsci/plugins/github/internal/GitHubClientCacheOpsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/internal/GitHubClientCacheOpsTest.java
@@ -49,7 +49,6 @@ public class GitHubClientCacheOpsTest {
     @Test
     public void shouldPointToDifferentCachesOnChangedApiPath() throws Exception {
         GitHubServerConfig config = new GitHubServerConfig(CREDENTIALS_ID);
-        config.setCustomApiUrl(true);
         config.setApiUrl(CUSTOM_API_URL);
 
         GitHubServerConfig config2 = new GitHubServerConfig(CREDENTIALS_ID);

--- a/src/test/java/org/jenkinsci/plugins/github/test/GHMockRule.java
+++ b/src/test/java/org/jenkinsci/plugins/github/test/GHMockRule.java
@@ -63,7 +63,6 @@ public class GHMockRule implements TestRule {
      */
     public GitHubServerConfig serverConfig() {
         GitHubServerConfig conf = new GitHubServerConfig("creds");
-        conf.setCustomApiUrl(true);
         conf.setApiUrl("http://localhost:" + service().port());
         return conf;
     }


### PR DESCRIPTION
See [JENKINS-33228](https://issues.jenkins-ci.org/browse/JENKINS-33228) for the context of this discussion.

This PR consists of a number of small changes to slightly improve the global configuration page.

`GitHubServerConfig` and especially its help text is still not really adequate for reuse by other plugins, but those requires further work.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/112)
<!-- Reviewable:end -->
