### PR TITLE
Extended setter for status

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubSetCommitStatusBuilder.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubSetCommitStatusBuilder.java
@@ -1,5 +1,6 @@
 package com.cloudbees.jenkins;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -9,21 +10,25 @@ import hudson.model.TaskListener;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import jenkins.tasks.SimpleBuildStep;
-
-import org.eclipse.jgit.lib.ObjectId;
 import org.jenkinsci.plugins.github.common.ExpandableMessage;
-import org.jenkinsci.plugins.github.util.BuildDataHelper;
+import org.jenkinsci.plugins.github.extension.status.StatusErrorHandler;
+import org.jenkinsci.plugins.github.extension.status.misc.ConditionalResult;
+import org.jenkinsci.plugins.github.status.GitHubCommitStatusSetter;
+import org.jenkinsci.plugins.github.status.err.ShallowAnyErrorHandler;
+import org.jenkinsci.plugins.github.status.sources.AnyDefinedRepositorySource;
+import org.jenkinsci.plugins.github.status.sources.BuildDataRevisionShaSource;
+import org.jenkinsci.plugins.github.status.sources.ConditionalStatusResultSource;
+import org.jenkinsci.plugins.github.status.sources.DefaultCommitContextSource;
 import org.kohsuke.github.GHCommitState;
-import org.kohsuke.github.GHRepository;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
 import java.io.IOException;
+import java.util.Collections;
 
-import static com.cloudbees.jenkins.Messages.GitHubCommitNotifier_SettingCommitStatus;
-import static com.coravy.hudson.plugins.github.GithubProjectProperty.displayNameFor;
 import static com.google.common.base.Objects.firstNonNull;
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
+import static org.jenkinsci.plugins.github.status.sources.misc.AnyBuildResult.onAnyResult;
 
 @Extension
 public class GitHubSetCommitStatusBuilder extends Builder implements SimpleBuildStep {
@@ -51,29 +56,27 @@ public class GitHubSetCommitStatusBuilder extends Builder implements SimpleBuild
     }
 
     @Override
-    public void perform(Run<?, ?> build,
-                        FilePath workspace,
-                        Launcher launcher,
-                        TaskListener listener) throws InterruptedException, IOException {
-        final String sha1 = ObjectId.toString(BuildDataHelper.getCommitSHA1(build));
-        String message = defaultIfEmpty(
-                firstNonNull(statusMessage, DEFAULT_MESSAGE).expandAll(build, listener),
-                Messages.CommitNotifier_Pending(build.getDisplayName())
-        );
-        String contextName = displayNameFor(build.getParent());
+    public void perform(@NonNull Run<?, ?> build,
+                        @NonNull FilePath workspace,
+                        @NonNull Launcher launcher,
+                        @NonNull TaskListener listener) throws InterruptedException, IOException {
 
-        for (GitHubRepositoryName name : GitHubRepositoryNameContributor.parseAssociatedNames(build.getParent())) {
-            for (GHRepository repository : name.resolve()) {
-                listener.getLogger().println(
-                        GitHubCommitNotifier_SettingCommitStatus(repository.getHtmlUrl() + "/commit/" + sha1)
-                );
-                repository.createCommitStatus(sha1,
-                        GHCommitState.PENDING,
-                        build.getAbsoluteUrl(),
-                        message,
-                        contextName);
-            }
-        }
+        GitHubCommitStatusSetter setter = new GitHubCommitStatusSetter();
+        setter.setReposSource(new AnyDefinedRepositorySource());
+        setter.setCommitShaSource(new BuildDataRevisionShaSource());
+        setter.setContextSource(new DefaultCommitContextSource());
+        setter.setErrorHandlers(Collections.<StatusErrorHandler>singletonList(new ShallowAnyErrorHandler()));
+
+        setter.setStatusResultSource(new ConditionalStatusResultSource(
+                Collections.<ConditionalResult>singletonList(
+                        onAnyResult(
+                                GHCommitState.PENDING,
+                                defaultIfEmpty(firstNonNull(statusMessage, DEFAULT_MESSAGE).getContent(),
+                                        Messages.CommitNotifier_Pending(build.getDisplayName()))
+                        )
+                )));
+
+        setter.perform(build, workspace, launcher, listener);
     }
 
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/github/common/CombineErrorHandler.java
+++ b/src/main/java/org/jenkinsci/plugins/github/common/CombineErrorHandler.java
@@ -1,0 +1,61 @@
+package org.jenkinsci.plugins.github.common;
+
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.apache.commons.collections.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+public class CombineErrorHandler implements ErrorHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(CombineErrorHandler.class);
+
+    private List<ErrorHandler> handlers = new ArrayList<>();
+
+    private CombineErrorHandler() {
+    }
+
+    public static CombineErrorHandler errorHandling() {
+        return new CombineErrorHandler();
+    }
+
+    public CombineErrorHandler withHandlers(List<? extends ErrorHandler> handlers) {
+        if (CollectionUtils.isEmpty(handlers)) {
+            this.handlers.addAll(handlers);
+        }
+        return this;
+    }
+
+    @Override
+    public boolean handle(Exception e, @Nonnull Run<?, ?> run, @Nonnull TaskListener listener) {
+        LOG.debug("Exception in {} ({})", run.getParent().getName(), e.getMessage(), e);
+        try {
+            for (ErrorHandler next : handlers) {
+                if (next.handle(e, run, listener)) {
+                    LOG.debug("Exception in {} ({}) handled by {}",
+                            run.getParent().getName(),
+                            e.getMessage(),
+                            next.getClass());
+                    return true;
+                }
+            }
+        } catch (Exception unhandled) {
+            LOG.error("Exception in {} ({}) unhandled", run.getParent().getName(), unhandled.getMessage(), unhandled);
+            throw new ErrorHandlingException(unhandled);
+        }
+
+        throw new ErrorHandlingException(e);
+    }
+
+    public static class ErrorHandlingException extends RuntimeException {
+        public ErrorHandlingException(Throwable cause) {
+            super(cause);
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/github/common/CombineErrorHandler.java
+++ b/src/main/java/org/jenkinsci/plugins/github/common/CombineErrorHandler.java
@@ -12,7 +12,12 @@ import java.util.List;
 import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
 
 /**
+ * With help of list of other error handlers handles exception.
+ * If no one will handle it, exception will be wrapped to {@link ErrorHandlingException}
+ * and thrown by the handle method
+ *
  * @author lanwen (Merkushev Kirill)
+ * @since 1.19.0
  */
 public class CombineErrorHandler implements ErrorHandler {
     private static final Logger LOG = LoggerFactory.getLogger(CombineErrorHandler.class);
@@ -22,6 +27,11 @@ public class CombineErrorHandler implements ErrorHandler {
     private CombineErrorHandler() {
     }
 
+    /**
+     * Static factory to produce new instance of this handler
+     *
+     * @return new instance
+     */
     public static CombineErrorHandler errorHandling() {
         return new CombineErrorHandler();
     }
@@ -33,6 +43,15 @@ public class CombineErrorHandler implements ErrorHandler {
         return this;
     }
 
+    /**
+     * Handles exception with help of other handlers. If no one will handle it, it will be thrown to the top level
+     *
+     * @param e        exception to handle (log, ignore, process, rethrow)
+     * @param run      run object from the step
+     * @param listener listener object from the step
+     *
+     * @return true if exception handled or rethrows it
+     */
     @Override
     public boolean handle(Exception e, @Nonnull Run<?, ?> run, @Nonnull TaskListener listener) {
         LOG.debug("Exception in {} will be processed with {} handlers",
@@ -55,6 +74,9 @@ public class CombineErrorHandler implements ErrorHandler {
         throw new ErrorHandlingException(e);
     }
 
+    /**
+     * Wrapper for the not handled by this handler exceptions
+     */
     public static class ErrorHandlingException extends RuntimeException {
         public ErrorHandlingException(Throwable cause) {
             super(cause);

--- a/src/main/java/org/jenkinsci/plugins/github/common/ErrorHandler.java
+++ b/src/main/java/org/jenkinsci/plugins/github/common/ErrorHandler.java
@@ -6,8 +6,25 @@ import hudson.model.TaskListener;
 import javax.annotation.Nonnull;
 
 /**
+ * So you can implement bunch of {@link ErrorHandler}s and log, rethrow, ignore exception.
+ * Useful to control own step exceptions
+ * (for example {@link org.jenkinsci.plugins.github.status.GitHubCommitStatusSetter})
+ *
  * @author lanwen (Merkushev Kirill)
+ * @since 1.19.0
  */
 public interface ErrorHandler {
+
+    /**
+     * Normally should return true if exception is handled and no other handler should do anything.
+     * If you will return false, the next error handler should try to handle this exception
+     *
+     * @param e        exception to handle (log, ignore, process, rethrow)
+     * @param run      run object from the step
+     * @param listener listener object from the step
+     *
+     * @return true if exception handled successfully
+     * @throws Exception you can rethrow exception of any type
+     */
     boolean handle(Exception e, @Nonnull Run<?, ?> run, @Nonnull TaskListener listener) throws Exception;
 }

--- a/src/main/java/org/jenkinsci/plugins/github/common/ErrorHandler.java
+++ b/src/main/java/org/jenkinsci/plugins/github/common/ErrorHandler.java
@@ -1,0 +1,13 @@
+package org.jenkinsci.plugins.github.common;
+
+import hudson.model.Run;
+import hudson.model.TaskListener;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+public interface ErrorHandler {
+    boolean handle(Exception e, @Nonnull Run<?, ?> run, @Nonnull TaskListener listener) throws Exception;
+}

--- a/src/main/java/org/jenkinsci/plugins/github/extension/status/GitHubCommitShaSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github/extension/status/GitHubCommitShaSource.java
@@ -9,10 +9,20 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 
 /**
+ * Extension point to provide commit sha which will be used to set state
+ *
  * @author lanwen (Merkushev Kirill)
+ * @since 1.19.0
  */
 public abstract class GitHubCommitShaSource extends AbstractDescribableImpl<GitHubCommitShaSource>
         implements ExtensionPoint {
 
-    public abstract String get(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener) throws IOException, InterruptedException;
+    /**
+     * @param run      enclosing run
+     * @param listener listener of the run. Can be used to fetch env vars
+     *
+     * @return plain sha to set state
+     */
+    public abstract String get(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener)
+            throws IOException, InterruptedException;
 }

--- a/src/main/java/org/jenkinsci/plugins/github/extension/status/GitHubCommitShaSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github/extension/status/GitHubCommitShaSource.java
@@ -14,5 +14,5 @@ import java.io.IOException;
 public abstract class GitHubCommitShaSource extends AbstractDescribableImpl<GitHubCommitShaSource>
         implements ExtensionPoint {
 
-    public abstract String get(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener) throws IOException;
+    public abstract String get(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener) throws IOException, InterruptedException;
 }

--- a/src/main/java/org/jenkinsci/plugins/github/extension/status/GitHubCommitShaSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github/extension/status/GitHubCommitShaSource.java
@@ -1,0 +1,18 @@
+package org.jenkinsci.plugins.github.extension.status;
+
+import hudson.ExtensionPoint;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+public abstract class GitHubCommitShaSource extends AbstractDescribableImpl<GitHubCommitShaSource>
+        implements ExtensionPoint {
+
+    public abstract String get(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener) throws IOException;
+}

--- a/src/main/java/org/jenkinsci/plugins/github/extension/status/GitHubReposSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github/extension/status/GitHubReposSource.java
@@ -10,9 +10,18 @@ import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
+ * Extension point to provide list of resolved repositories where commit is located
+ *
  * @author lanwen (Merkushev Kirill)
+ * @since 1.19.0
  */
 public abstract class GitHubReposSource extends AbstractDescribableImpl<GitHubReposSource> implements ExtensionPoint {
 
+    /**
+     * @param run      actual run
+     * @param listener build listener
+     *
+     * @return resolved list of GitHub repositories
+     */
     public abstract List<GHRepository> repos(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener);
 }

--- a/src/main/java/org/jenkinsci/plugins/github/extension/status/GitHubReposSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github/extension/status/GitHubReposSource.java
@@ -1,0 +1,18 @@
+package org.jenkinsci.plugins.github.extension.status;
+
+import hudson.ExtensionPoint;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.kohsuke.github.GHRepository;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+public abstract class GitHubReposSource extends AbstractDescribableImpl<GitHubReposSource> implements ExtensionPoint {
+
+    public abstract List<GHRepository> repos(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener);
+}

--- a/src/main/java/org/jenkinsci/plugins/github/extension/status/GitHubStatusContextSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github/extension/status/GitHubStatusContextSource.java
@@ -1,0 +1,17 @@
+package org.jenkinsci.plugins.github.extension.status;
+
+import hudson.ExtensionPoint;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+public abstract class GitHubStatusContextSource extends AbstractDescribableImpl<GitHubStatusContextSource>
+        implements ExtensionPoint {
+
+    public abstract String context(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener);
+}

--- a/src/main/java/org/jenkinsci/plugins/github/extension/status/GitHubStatusContextSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github/extension/status/GitHubStatusContextSource.java
@@ -8,10 +8,19 @@ import hudson.model.TaskListener;
 import javax.annotation.Nonnull;
 
 /**
+ * Extension point to provide context of the state. For example `integration-tests` or `build`
+ *
  * @author lanwen (Merkushev Kirill)
+ * @since 1.19.0
  */
 public abstract class GitHubStatusContextSource extends AbstractDescribableImpl<GitHubStatusContextSource>
         implements ExtensionPoint {
 
+    /**
+     * @param run      actual run
+     * @param listener build listener
+     *
+     * @return simple short string to represent context of this state
+     */
     public abstract String context(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener);
 }

--- a/src/main/java/org/jenkinsci/plugins/github/extension/status/GitHubStatusResultSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github/extension/status/GitHubStatusResultSource.java
@@ -1,0 +1,36 @@
+package org.jenkinsci.plugins.github.extension.status;
+
+import hudson.ExtensionPoint;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.kohsuke.github.GHCommitState;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+public abstract class GitHubStatusResultSource extends AbstractDescribableImpl<GitHubStatusResultSource>
+        implements ExtensionPoint {
+
+    public abstract StatusResult get(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener);
+
+    public static class StatusResult {
+        private GHCommitState state;
+        private String msg;
+
+        public StatusResult(GHCommitState state, String msg) {
+            this.state = state;
+            this.msg = msg;
+        }
+
+        public GHCommitState getState() {
+            return state;
+        }
+
+        public String getMsg() {
+            return msg;
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/github/extension/status/GitHubStatusResultSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github/extension/status/GitHubStatusResultSource.java
@@ -7,6 +7,7 @@ import hudson.model.TaskListener;
 import org.kohsuke.github.GHCommitState;
 
 import javax.annotation.Nonnull;
+import java.io.IOException;
 
 /**
  * @author lanwen (Merkushev Kirill)
@@ -14,7 +15,8 @@ import javax.annotation.Nonnull;
 public abstract class GitHubStatusResultSource extends AbstractDescribableImpl<GitHubStatusResultSource>
         implements ExtensionPoint {
 
-    public abstract StatusResult get(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener);
+    public abstract StatusResult get(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener) 
+            throws IOException, InterruptedException;
 
     public static class StatusResult {
         private GHCommitState state;

--- a/src/main/java/org/jenkinsci/plugins/github/extension/status/GitHubStatusResultSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github/extension/status/GitHubStatusResultSource.java
@@ -10,14 +10,26 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 
 /**
+ * Extension point to provide exact state and message for the commit
+ *
  * @author lanwen (Merkushev Kirill)
+ * @since 1.19.0
  */
 public abstract class GitHubStatusResultSource extends AbstractDescribableImpl<GitHubStatusResultSource>
         implements ExtensionPoint {
 
-    public abstract StatusResult get(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener) 
+    /**
+     * @param run      actual run
+     * @param listener run listener
+     *
+     * @return bean with state and already expanded message
+     */
+    public abstract StatusResult get(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener)
             throws IOException, InterruptedException;
 
+    /**
+     * Bean with state and msg info
+     */
     public static class StatusResult {
         private GHCommitState state;
         private String msg;

--- a/src/main/java/org/jenkinsci/plugins/github/extension/status/StatusErrorHandler.java
+++ b/src/main/java/org/jenkinsci/plugins/github/extension/status/StatusErrorHandler.java
@@ -1,0 +1,19 @@
+package org.jenkinsci.plugins.github.extension.status;
+
+import hudson.DescriptorExtensionList;
+import hudson.ExtensionPoint;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.github.common.ErrorHandler;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+public abstract class StatusErrorHandler extends AbstractDescribableImpl<StatusErrorHandler>
+        implements ErrorHandler, ExtensionPoint {
+
+    public static DescriptorExtensionList<StatusErrorHandler, Descriptor<StatusErrorHandler>> all() {
+        return Jenkins.getInstance().getDescriptorList(StatusErrorHandler.class);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/github/extension/status/StatusErrorHandler.java
+++ b/src/main/java/org/jenkinsci/plugins/github/extension/status/StatusErrorHandler.java
@@ -8,11 +8,19 @@ import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.github.common.ErrorHandler;
 
 /**
+ * Extension point to provide way of how to react on errors in status setter step
+ *
  * @author lanwen (Merkushev Kirill)
+ * @since 1.19.0
  */
 public abstract class StatusErrorHandler extends AbstractDescribableImpl<StatusErrorHandler>
         implements ErrorHandler, ExtensionPoint {
 
+    /**
+     * Used in view
+     *
+     * @return all of the available error handlers.
+     */
     public static DescriptorExtensionList<StatusErrorHandler, Descriptor<StatusErrorHandler>> all() {
         return Jenkins.getInstance().getDescriptorList(StatusErrorHandler.class);
     }

--- a/src/main/java/org/jenkinsci/plugins/github/extension/status/misc/ConditionalResult.java
+++ b/src/main/java/org/jenkinsci/plugins/github/extension/status/misc/ConditionalResult.java
@@ -22,8 +22,8 @@ import javax.annotation.Nonnull;
  */
 public abstract class ConditionalResult extends AbstractDescribableImpl<ConditionalResult> implements ExtensionPoint {
 
-    protected String state;
-    protected String message;
+    private String state;
+    private String message;
 
     @DataBoundSetter
     public void setState(String state) {

--- a/src/main/java/org/jenkinsci/plugins/github/extension/status/misc/ConditionalResult.java
+++ b/src/main/java/org/jenkinsci/plugins/github/extension/status/misc/ConditionalResult.java
@@ -40,7 +40,7 @@ public abstract class ConditionalResult extends AbstractDescribableImpl<Conditio
 
     public abstract boolean matches(@Nonnull Run<?, ?> run);
 
-    public static abstract class ConditionalResultDescriptor extends Descriptor<ConditionalResult> {
+    public abstract static class ConditionalResultDescriptor extends Descriptor<ConditionalResult> {
 
         public static DescriptorExtensionList<ConditionalResult, Descriptor<ConditionalResult>> all() {
             return Jenkins.getInstance().getDescriptorList(ConditionalResult.class);

--- a/src/main/java/org/jenkinsci/plugins/github/extension/status/misc/ConditionalResult.java
+++ b/src/main/java/org/jenkinsci/plugins/github/extension/status/misc/ConditionalResult.java
@@ -13,16 +13,21 @@ import org.kohsuke.stapler.DataBoundSetter;
 import javax.annotation.Nonnull;
 
 /**
+ * This extension point allows to define when and what to send as state and message.
+ * It will be used as part of {@link org.jenkinsci.plugins.github.status.sources.ConditionalStatusResultSource}.
+ *
  * @author lanwen (Merkushev Kirill)
+ * @see org.jenkinsci.plugins.github.status.sources.misc.BetterThanOrEqualBuildResult
+ * @since 1.19.0
  */
 public abstract class ConditionalResult extends AbstractDescribableImpl<ConditionalResult> implements ExtensionPoint {
 
-    protected String status;
+    protected String state;
     protected String message;
 
     @DataBoundSetter
-    public void setStatus(String status) {
-        this.status = status;
+    public void setState(String state) {
+        this.state = state;
     }
 
     @DataBoundSetter
@@ -30,30 +35,52 @@ public abstract class ConditionalResult extends AbstractDescribableImpl<Conditio
         this.message = message;
     }
 
-    public String getStatus() {
-        return status;
+    /**
+     * @return State to set. Will be converted to {@link GHCommitState}
+     */
+    public String getState() {
+        return state;
     }
 
+    /**
+     * @return Message to write. Can contain env vars, will be expanded.
+     */
     public String getMessage() {
         return message;
     }
 
+    /**
+     * If matches, will be used to set state
+     *
+     * @param run to check against
+     *
+     * @return true if matches
+     */
     public abstract boolean matches(@Nonnull Run<?, ?> run);
 
+    /**
+     * Should be extended to and marked as {@link hudson.Extension} to be in list
+     */
     public abstract static class ConditionalResultDescriptor extends Descriptor<ConditionalResult> {
 
+        /**
+         * Gets all available extensions. Used in view
+         *
+         * @return all descriptors of conditional results
+         */
         public static DescriptorExtensionList<ConditionalResult, Descriptor<ConditionalResult>> all() {
             return Jenkins.getInstance().getDescriptorList(ConditionalResult.class);
         }
 
-        public ListBoxModel doFillStatusItems() {
+        /**
+         * @return options to fill state items in view
+         */
+        public ListBoxModel doFillStateItems() {
             ListBoxModel items = new ListBoxModel();
-            for (GHCommitState status1 : GHCommitState.values()) {
-                items.add(status1.name());
+            for (GHCommitState commitState : GHCommitState.values()) {
+                items.add(commitState.name());
             }
             return items;
         }
-    } 
-
-
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/github/extension/status/misc/ConditionalResult.java
+++ b/src/main/java/org/jenkinsci/plugins/github/extension/status/misc/ConditionalResult.java
@@ -1,0 +1,59 @@
+package org.jenkinsci.plugins.github.extension.status.misc;
+
+import hudson.DescriptorExtensionList;
+import hudson.ExtensionPoint;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import hudson.model.Run;
+import hudson.util.ListBoxModel;
+import jenkins.model.Jenkins;
+import org.kohsuke.github.GHCommitState;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+public abstract class ConditionalResult extends AbstractDescribableImpl<ConditionalResult> implements ExtensionPoint {
+
+    protected String status;
+    protected String message;
+
+    @DataBoundSetter
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    @DataBoundSetter
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public abstract boolean matches(@Nonnull Run<?, ?> run);
+
+    public static abstract class ConditionalResultDescriptor extends Descriptor<ConditionalResult> {
+
+        public static DescriptorExtensionList<ConditionalResult, Descriptor<ConditionalResult>> all() {
+            return Jenkins.getInstance().getDescriptorList(ConditionalResult.class);
+        }
+
+        public ListBoxModel doFillStatusItems() {
+            ListBoxModel items = new ListBoxModel();
+            for (GHCommitState status1 : GHCommitState.values()) {
+                items.add(status1.name());
+            }
+            return items;
+        }
+    } 
+
+
+}

--- a/src/main/java/org/jenkinsci/plugins/github/status/GitHubCommitStatusSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/GitHubCommitStatusSetter.java
@@ -12,15 +12,15 @@ import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
 import jenkins.tasks.SimpleBuildStep;
 import org.jenkinsci.plugins.github.common.CombineErrorHandler;
-import org.jenkinsci.plugins.github.extension.status.StatusErrorHandler;
-import org.jenkinsci.plugins.github.status.sources.AnyDefinedRepositorySource;
-import org.jenkinsci.plugins.github.status.sources.DefaultCommitContextSource;
-import org.jenkinsci.plugins.github.status.sources.DefaultStatusResultSource;
-import org.jenkinsci.plugins.github.status.sources.BuildDataRevisionShaSource;
 import org.jenkinsci.plugins.github.extension.status.GitHubCommitShaSource;
 import org.jenkinsci.plugins.github.extension.status.GitHubReposSource;
 import org.jenkinsci.plugins.github.extension.status.GitHubStatusContextSource;
 import org.jenkinsci.plugins.github.extension.status.GitHubStatusResultSource;
+import org.jenkinsci.plugins.github.extension.status.StatusErrorHandler;
+import org.jenkinsci.plugins.github.status.sources.AnyDefinedRepositorySource;
+import org.jenkinsci.plugins.github.status.sources.BuildDataRevisionShaSource;
+import org.jenkinsci.plugins.github.status.sources.DefaultCommitContextSource;
+import org.jenkinsci.plugins.github.status.sources.DefaultStatusResultSource;
 import org.kohsuke.github.GHCommitState;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -33,7 +33,10 @@ import java.util.List;
 import static com.cloudbees.jenkins.Messages.GitHubCommitNotifier_SettingCommitStatus;
 
 /**
+ * Create commit state notifications on the commits based on the outcome of the build.
+ *
  * @author lanwen (Merkushev Kirill)
+ * @since 1.19.0
  */
 public class GitHubCommitStatusSetter extends Notifier implements SimpleBuildStep {
 
@@ -72,26 +75,44 @@ public class GitHubCommitStatusSetter extends Notifier implements SimpleBuildSte
         this.errorHandlers = errorHandlers;
     }
 
+    /**
+     * @return SHA provider
+     */
     public GitHubCommitShaSource getCommitShaSource() {
         return commitShaSource;
     }
 
+    /**
+     * @return Repository list provider
+     */
     public GitHubReposSource getReposSource() {
         return reposSource;
     }
 
+    /**
+     * @return Context provider
+     */
     public GitHubStatusContextSource getContextSource() {
         return contextSource;
     }
 
+    /**
+     * @return state + msg provider
+     */
     public GitHubStatusResultSource getStatusResultSource() {
         return statusResultSource;
     }
 
+    /**
+     * @return error handlers
+     */
     public List<StatusErrorHandler> getErrorHandlers() {
         return errorHandlers;
     }
 
+    /**
+     * Gets info from the providers and updates commit status
+     */
     @Override
     public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher,
                         @Nonnull TaskListener listener) {
@@ -135,7 +156,7 @@ public class GitHubCommitStatusSetter extends Notifier implements SimpleBuildSte
 
         @Override
         public String getDisplayName() {
-            return "[NEW] Set status for GitHub";
+            return "[NEW] Set status for GitHub commit";
         }
 
     }

--- a/src/main/java/org/jenkinsci/plugins/github/status/GitHubCommitStatusSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/GitHubCommitStatusSetter.java
@@ -30,6 +30,8 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.cloudbees.jenkins.Messages.GitHubCommitNotifier_SettingCommitStatus;
+
 /**
  * @author lanwen (Merkushev Kirill)
  */
@@ -106,6 +108,10 @@ public class GitHubCommitStatusSetter extends Notifier implements SimpleBuildSte
             GHCommitState state = result.getState();
 
             for (GHRepository repo : repos) {
+                listener.getLogger().println(
+                        GitHubCommitNotifier_SettingCommitStatus(repo.getHtmlUrl() + "/commit/" + sha)
+                );
+
                 repo.createCommitStatus(sha, state, backref, message, contextName);
             }
 

--- a/src/main/java/org/jenkinsci/plugins/github/status/GitHubCommitStatusSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/GitHubCommitStatusSetter.java
@@ -156,7 +156,7 @@ public class GitHubCommitStatusSetter extends Notifier implements SimpleBuildSte
 
         @Override
         public String getDisplayName() {
-            return "[NEW] Set status for GitHub commit";
+            return "Set status for GitHub commit [universal]";
         }
 
     }

--- a/src/main/java/org/jenkinsci/plugins/github/status/GitHubCommitStatusSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/GitHubCommitStatusSetter.java
@@ -1,0 +1,136 @@
+package org.jenkinsci.plugins.github.status;
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.AbstractProject;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Notifier;
+import hudson.tasks.Publisher;
+import jenkins.tasks.SimpleBuildStep;
+import org.jenkinsci.plugins.github.common.CombineErrorHandler;
+import org.jenkinsci.plugins.github.extension.status.StatusErrorHandler;
+import org.jenkinsci.plugins.github.status.sources.AnyDefinedRepositorySource;
+import org.jenkinsci.plugins.github.status.sources.DefaultCommitContextSource;
+import org.jenkinsci.plugins.github.status.sources.DefaultStatusResultSource;
+import org.jenkinsci.plugins.github.status.sources.BuildDataRevisionShaSource;
+import org.jenkinsci.plugins.github.extension.status.GitHubCommitShaSource;
+import org.jenkinsci.plugins.github.extension.status.GitHubReposSource;
+import org.jenkinsci.plugins.github.extension.status.GitHubStatusContextSource;
+import org.jenkinsci.plugins.github.extension.status.GitHubStatusResultSource;
+import org.kohsuke.github.GHCommitState;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+public class GitHubCommitStatusSetter extends Notifier implements SimpleBuildStep {
+
+    private GitHubCommitShaSource commitShaSource = new BuildDataRevisionShaSource();
+    private GitHubReposSource reposSource = new AnyDefinedRepositorySource();
+    private GitHubStatusContextSource contextSource = new DefaultCommitContextSource();
+    private GitHubStatusResultSource statusResultSource = new DefaultStatusResultSource();
+    private List<StatusErrorHandler> errorHandlers = new ArrayList<>();
+
+    @DataBoundConstructor
+    public GitHubCommitStatusSetter() {
+    }
+
+    @DataBoundSetter
+    public void setCommitShaSource(GitHubCommitShaSource commitShaSource) {
+        this.commitShaSource = commitShaSource;
+    }
+
+    @DataBoundSetter
+    public void setReposSource(GitHubReposSource reposSource) {
+        this.reposSource = reposSource;
+    }
+
+    @DataBoundSetter
+    public void setContextSource(GitHubStatusContextSource contextSource) {
+        this.contextSource = contextSource;
+    }
+
+    @DataBoundSetter
+    public void setStatusResultSource(GitHubStatusResultSource statusResultSource) {
+        this.statusResultSource = statusResultSource;
+    }
+
+    @DataBoundSetter
+    public void setErrorHandlers(List<StatusErrorHandler> errorHandlers) {
+        this.errorHandlers = errorHandlers;
+    }
+
+    public GitHubCommitShaSource getCommitShaSource() {
+        return commitShaSource;
+    }
+
+    public GitHubReposSource getReposSource() {
+        return reposSource;
+    }
+
+    public GitHubStatusContextSource getContextSource() {
+        return contextSource;
+    }
+
+    public GitHubStatusResultSource getStatusResultSource() {
+        return statusResultSource;
+    }
+
+    public List<StatusErrorHandler> getErrorHandlers() {
+        return errorHandlers;
+    }
+
+    @Override
+    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher,
+                        @Nonnull TaskListener listener) {
+        try {
+            String sha = getCommitShaSource().get(run, listener);
+            List<GHRepository> repos = getReposSource().repos(run, listener);
+            String contextName = getContextSource().context(run, listener);
+
+            String backref = run.getAbsoluteUrl();
+
+            GitHubStatusResultSource.StatusResult result = getStatusResultSource().get(run, listener);
+
+            String message = result.getMsg();
+            GHCommitState state = result.getState();
+
+            for (GHRepository repo : repos) {
+                repo.createCommitStatus(sha, state, backref, message, contextName);
+            }
+
+        } catch (Exception e) {
+            CombineErrorHandler.errorHandling().withHandlers(getErrorHandlers()).handle(e, run, listener);
+        }
+    }
+
+    @Override
+    public BuildStepMonitor getRequiredMonitorService() {
+        return BuildStepMonitor.NONE;
+    }
+
+
+    @Extension
+    public static class GitHubCommitStatusSetterDescr extends BuildStepDescriptor<Publisher> {
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            return true;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "[NEW] Set status for GitHub";
+        }
+
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/github/status/err/ChangingBuildStatusErrorHandler.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/err/ChangingBuildStatusErrorHandler.java
@@ -16,7 +16,10 @@ import static hudson.model.Result.UNSTABLE;
 import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 
 /**
+ * Can change build status in case of errors
+ *
  * @author lanwen (Merkushev Kirill)
+ * @since 1.19.0
  */
 public class ChangingBuildStatusErrorHandler extends StatusErrorHandler {
 
@@ -31,6 +34,11 @@ public class ChangingBuildStatusErrorHandler extends StatusErrorHandler {
         return result;
     }
 
+    /**
+     * Logs error to build console and changes build result
+     *
+     * @return true as of it terminating handler
+     */
     @Override
     public boolean handle(Exception e, @Nonnull Run<?, ?> run, @Nonnull TaskListener listener) {
         Result toSet = Result.fromString(trimToEmpty(result));
@@ -43,11 +51,12 @@ public class ChangingBuildStatusErrorHandler extends StatusErrorHandler {
 
     @Extension
     public static class ChangingBuildStatusErrorHandlerDescriptor extends Descriptor<StatusErrorHandler> {
+        
         private static final Result[] SUPPORTED_RESULTS = {
-                FAILURE, 
+                FAILURE,
                 UNSTABLE,
         };
-        
+
         @Override
         public String getDisplayName() {
             return "Change build status";

--- a/src/main/java/org/jenkinsci/plugins/github/status/err/ChangingBuildStatusErrorHandler.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/err/ChangingBuildStatusErrorHandler.java
@@ -51,11 +51,8 @@ public class ChangingBuildStatusErrorHandler extends StatusErrorHandler {
 
     @Extension
     public static class ChangingBuildStatusErrorHandlerDescriptor extends Descriptor<StatusErrorHandler> {
-        
-        private static final Result[] SUPPORTED_RESULTS = {
-                FAILURE,
-                UNSTABLE,
-        };
+
+        private static final Result[] SUPPORTED_RESULTS = {FAILURE, UNSTABLE};
 
         @Override
         public String getDisplayName() {

--- a/src/main/java/org/jenkinsci/plugins/github/status/err/ChangingBuildStatusErrorHandler.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/err/ChangingBuildStatusErrorHandler.java
@@ -1,0 +1,65 @@
+package org.jenkinsci.plugins.github.status.err;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.util.ListBoxModel;
+import org.jenkinsci.plugins.github.extension.status.StatusErrorHandler;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+
+import static hudson.model.Result.FAILURE;
+import static hudson.model.Result.UNSTABLE;
+import static org.apache.commons.lang3.StringUtils.trimToEmpty;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+public class ChangingBuildStatusErrorHandler extends StatusErrorHandler {
+
+    private String result;
+
+    @DataBoundConstructor
+    public ChangingBuildStatusErrorHandler(String result) {
+        this.result = result;
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    @Override
+    public boolean handle(Exception e, @Nonnull Run<?, ?> run, @Nonnull TaskListener listener) {
+        Result toSet = Result.fromString(trimToEmpty(result));
+
+        listener.error("[GitHub Commit Status Setter] - %s, setting build result to %s", e.getMessage(), toSet);
+
+        run.setResult(toSet);
+        return true;
+    }
+
+    @Extension
+    public static class ChangingBuildStatusErrorHandlerDescriptor extends Descriptor<StatusErrorHandler> {
+        private static final Result[] SUPPORTED_RESULTS = {
+                FAILURE, 
+                UNSTABLE
+        };
+        
+        @Override
+        public String getDisplayName() {
+            return "Change build status";
+        }
+
+        @SuppressWarnings("unused")
+        public ListBoxModel doFillResultItems() {
+            ListBoxModel items = new ListBoxModel();
+            for (Result result : SUPPORTED_RESULTS) {
+                items.add(result.toString());
+            }
+            return items;
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/github/status/err/ShallowAnyErrorHandler.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/err/ShallowAnyErrorHandler.java
@@ -1,0 +1,34 @@
+package org.jenkinsci.plugins.github.status.err;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.github.extension.status.StatusErrorHandler;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+public class ShallowAnyErrorHandler extends StatusErrorHandler {
+
+    @DataBoundConstructor
+    public ShallowAnyErrorHandler() {
+    }
+
+    @Override
+    public boolean handle(Exception e, @Nonnull Run<?, ?> run, @Nonnull TaskListener listener) {
+        listener.error("Exception with status setter (%s) ignored", e.getMessage());
+        return true;
+    }
+
+    @Extension
+    public static class ShallowAnyErrorHandlerDescriptor extends Descriptor<StatusErrorHandler> {
+        @Override
+        public String getDisplayName() {
+            return "Just ignore any errors";
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/github/status/err/ShallowAnyErrorHandler.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/err/ShallowAnyErrorHandler.java
@@ -26,8 +26,8 @@ public class ShallowAnyErrorHandler extends StatusErrorHandler {
      */
     @Override
     public boolean handle(Exception e, @Nonnull Run<?, ?> run, @Nonnull TaskListener listener) {
-        listener.error("[GitHub Commit Status Setter] Failed to update commit state on GitHub. " +
-                "Ignoring exception [%s]", e.getMessage());
+        listener.error("[GitHub Commit Status Setter] Failed to update commit state on GitHub. "
+                + "Ignoring exception [%s]", e.getMessage());
         return true;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/github/status/err/ShallowAnyErrorHandler.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/err/ShallowAnyErrorHandler.java
@@ -20,7 +20,8 @@ public class ShallowAnyErrorHandler extends StatusErrorHandler {
 
     @Override
     public boolean handle(Exception e, @Nonnull Run<?, ?> run, @Nonnull TaskListener listener) {
-        listener.error("Exception with status setter (%s) ignored", e.getMessage());
+        listener.error("[GitHub Commit Status Setter] Failed to update commit status on GitHub. " +
+                "Ignoring exception [%s]", e.getMessage());
         return true;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/github/status/err/ShallowAnyErrorHandler.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/err/ShallowAnyErrorHandler.java
@@ -10,7 +10,10 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import javax.annotation.Nonnull;
 
 /**
+ * Just logs message to the build console and do nothing after it
+ *
  * @author lanwen (Merkushev Kirill)
+ * @since 1.19.0
  */
 public class ShallowAnyErrorHandler extends StatusErrorHandler {
 
@@ -18,9 +21,12 @@ public class ShallowAnyErrorHandler extends StatusErrorHandler {
     public ShallowAnyErrorHandler() {
     }
 
+    /**
+     * @return true as of its terminating handler
+     */
     @Override
     public boolean handle(Exception e, @Nonnull Run<?, ?> run, @Nonnull TaskListener listener) {
-        listener.error("[GitHub Commit Status Setter] Failed to update commit status on GitHub. " +
+        listener.error("[GitHub Commit Status Setter] Failed to update commit state on GitHub. " +
                 "Ignoring exception [%s]", e.getMessage());
         return true;
     }

--- a/src/main/java/org/jenkinsci/plugins/github/status/sources/AnyDefinedRepositorySource.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/sources/AnyDefinedRepositorySource.java
@@ -18,7 +18,10 @@ import java.util.List;
 import static org.jenkinsci.plugins.github.util.FluentIterableWrapper.from;
 
 /**
+ * Just uses contributors to get list of resolved repositories
+ *
  * @author lanwen (Merkushev Kirill)
+ * @since 1.19.0
  */
 public class AnyDefinedRepositorySource extends GitHubReposSource {
 
@@ -26,6 +29,9 @@ public class AnyDefinedRepositorySource extends GitHubReposSource {
     public AnyDefinedRepositorySource() {
     }
 
+    /**
+     * @return all repositories which can be found by repo-contributors
+     */
     @Override
     public List<GHRepository> repos(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener) {
         final Collection<GitHubRepositoryName> names = GitHubRepositoryNameContributor

--- a/src/main/java/org/jenkinsci/plugins/github/status/sources/AnyDefinedRepositorySource.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/sources/AnyDefinedRepositorySource.java
@@ -1,0 +1,48 @@
+package org.jenkinsci.plugins.github.status.sources;
+
+import com.cloudbees.jenkins.GitHubRepositoryName;
+import com.cloudbees.jenkins.GitHubRepositoryNameContributor;
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.github.extension.status.GitHubReposSource;
+import org.jenkinsci.plugins.github.util.misc.NullSafeFunction;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.List;
+
+import static org.jenkinsci.plugins.github.util.FluentIterableWrapper.from;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+public class AnyDefinedRepositorySource extends GitHubReposSource {
+
+    @DataBoundConstructor
+    public AnyDefinedRepositorySource() {
+    }
+
+    @Override
+    public List<GHRepository> repos(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener) {
+        final Collection<GitHubRepositoryName> names = GitHubRepositoryNameContributor
+                .parseAssociatedNames(run.getParent());
+        return from(names).transformAndConcat(new NullSafeFunction<GitHubRepositoryName, Iterable<GHRepository>>() {
+            @Override
+            protected Iterable<GHRepository> applyNullSafe(@Nonnull GitHubRepositoryName name) {
+                return name.resolve();
+            }
+        }).toList();
+    }
+
+    @Extension
+    public static class AnyDefinedRepoSourceDescriptor extends Descriptor<GitHubReposSource> {
+        @Override
+        public String getDisplayName() {
+            return "Any defined in job repository";
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/github/status/sources/BuildDataRevisionShaSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/sources/BuildDataRevisionShaSource.java
@@ -1,0 +1,36 @@
+package org.jenkinsci.plugins.github.status.sources;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.eclipse.jgit.lib.ObjectId;
+import org.jenkinsci.plugins.github.extension.status.GitHubCommitShaSource;
+import org.jenkinsci.plugins.github.util.BuildDataHelper;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+public class BuildDataRevisionShaSource extends GitHubCommitShaSource {
+
+    @DataBoundConstructor
+    public BuildDataRevisionShaSource() {
+    }
+
+    @Override
+    public String get(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener) throws IOException {
+        return ObjectId.toString(BuildDataHelper.getCommitSHA1(run));
+    }
+
+    @Extension
+    public static class BuildDataRevisionShaSourceDescriptor extends Descriptor<GitHubCommitShaSource> {
+        @Override
+        public String getDisplayName() {
+            return "Latest build revision";
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/github/status/sources/BuildDataRevisionShaSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/sources/BuildDataRevisionShaSource.java
@@ -13,7 +13,10 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 
 /**
+ * Gets sha from build data
+ *
  * @author lanwen (Merkushev Kirill)
+ * @since 1.19.0
  */
 public class BuildDataRevisionShaSource extends GitHubCommitShaSource {
 
@@ -21,6 +24,9 @@ public class BuildDataRevisionShaSource extends GitHubCommitShaSource {
     public BuildDataRevisionShaSource() {
     }
 
+    /**
+     * @return sha from git's scm build data action
+     */
     @Override
     public String get(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener) throws IOException {
         return ObjectId.toString(BuildDataHelper.getCommitSHA1(run));

--- a/src/main/java/org/jenkinsci/plugins/github/status/sources/ConditionalStatusResultSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/sources/ConditionalStatusResultSource.java
@@ -21,6 +21,8 @@ import static org.kohsuke.github.GHCommitState.ERROR;
 import static org.kohsuke.github.GHCommitState.PENDING;
 
 /**
+ * Allows to define message and state for commit for different run results
+ *
  * @author lanwen (Merkushev Kirill)
  */
 public class ConditionalStatusResultSource extends GitHubStatusResultSource {

--- a/src/main/java/org/jenkinsci/plugins/github/status/sources/ConditionalStatusResultSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/sources/ConditionalStatusResultSource.java
@@ -1,0 +1,77 @@
+package org.jenkinsci.plugins.github.status.sources;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.util.ListBoxModel;
+import org.apache.commons.lang3.EnumUtils;
+import org.jenkinsci.plugins.github.common.ExpandableMessage;
+import org.jenkinsci.plugins.github.extension.status.GitHubStatusResultSource;
+import org.jenkinsci.plugins.github.extension.status.misc.ConditionalResult;
+import org.kohsuke.github.GHCommitState;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import static org.kohsuke.github.GHCommitState.ERROR;
+import static org.kohsuke.github.GHCommitState.PENDING;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+public class ConditionalStatusResultSource extends GitHubStatusResultSource {
+
+    private List<ConditionalResult> results;
+
+    @DataBoundConstructor
+    public ConditionalStatusResultSource(List<ConditionalResult> results) {
+        this.results = results;
+    }
+
+    @Nonnull
+    public List<ConditionalResult> getResults() {
+        return defaultIfNull(results, Collections.<ConditionalResult>emptyList());
+    }
+
+    @Override
+    public StatusResult get(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener)
+            throws IOException, InterruptedException {
+
+        for (ConditionalResult conditionalResult : getResults()) {
+            if (conditionalResult.matches(run)) {
+                return new StatusResult(
+                        defaultIfNull(EnumUtils.getEnum(GHCommitState.class, conditionalResult.getStatus()), ERROR),
+                        new ExpandableMessage(conditionalResult.getMessage()).expandAll(run, listener)
+                );
+            }
+        }
+
+        return new StatusResult(
+                PENDING,
+                new ExpandableMessage("Can't define which status to set").expandAll(run, listener)
+        );
+    }
+
+    @Extension
+    public static class ConditionalStatusResultSourceDescriptor extends Descriptor<GitHubStatusResultSource> {
+        @Override
+        public String getDisplayName() {
+            return "Based on build result manually defined";
+        }
+
+        @SuppressWarnings("unused")
+        public ListBoxModel doFillStatusItems() {
+            ListBoxModel items = new ListBoxModel();
+            for (GHCommitState status : GHCommitState.values()) {
+                items.add(status.name());
+            }
+            return items;
+        }
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/github/status/sources/DefaultCommitContextSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/sources/DefaultCommitContextSource.java
@@ -1,0 +1,35 @@
+package org.jenkinsci.plugins.github.status.sources;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.github.extension.status.GitHubStatusContextSource;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+
+import static com.coravy.hudson.plugins.github.GithubProjectProperty.displayNameFor;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+public class DefaultCommitContextSource extends GitHubStatusContextSource {
+    
+    @DataBoundConstructor
+    public DefaultCommitContextSource() {
+    }
+
+    @Override
+    public String context(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener) {
+        return displayNameFor(run.getParent());
+    }
+
+    @Extension
+    public static class DefaultContextSourceDescriptor extends Descriptor<GitHubStatusContextSource> {
+        @Override
+        public String getDisplayName() {
+            return "From GitHub property with fallback to job name";
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/github/status/sources/DefaultCommitContextSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/sources/DefaultCommitContextSource.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.github.status.sources;
 
 import hudson.Extension;
 import hudson.model.Descriptor;
+import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.github.extension.status.GitHubStatusContextSource;
@@ -12,14 +13,21 @@ import javax.annotation.Nonnull;
 import static com.coravy.hudson.plugins.github.GithubProjectProperty.displayNameFor;
 
 /**
+ * Uses job name or defined in prop context name
+ *
  * @author lanwen (Merkushev Kirill)
+ * @since 1.19.0
  */
 public class DefaultCommitContextSource extends GitHubStatusContextSource {
-    
+
     @DataBoundConstructor
     public DefaultCommitContextSource() {
     }
 
+    /**
+     * @return context name
+     * @see com.coravy.hudson.plugins.github.GithubProjectProperty#displayNameFor(Job)
+     */
     @Override
     public String context(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener) {
         return displayNameFor(run.getParent());

--- a/src/main/java/org/jenkinsci/plugins/github/status/sources/DefaultCommitContextSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/sources/DefaultCommitContextSource.java
@@ -2,7 +2,6 @@ package org.jenkinsci.plugins.github.status.sources;
 
 import hudson.Extension;
 import hudson.model.Descriptor;
-import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.github.extension.status.GitHubStatusContextSource;
@@ -26,7 +25,7 @@ public class DefaultCommitContextSource extends GitHubStatusContextSource {
 
     /**
      * @return context name
-     * @see com.coravy.hudson.plugins.github.GithubProjectProperty#displayNameFor(Job)
+     * @see com.coravy.hudson.plugins.github.GithubProjectProperty#displayNameFor(hudson.model.Job)
      */
     @Override
     public String context(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener) {

--- a/src/main/java/org/jenkinsci/plugins/github/status/sources/DefaultStatusResultSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/sources/DefaultStatusResultSource.java
@@ -1,0 +1,65 @@
+package org.jenkinsci.plugins.github.status.sources;
+
+import com.cloudbees.jenkins.Messages;
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.Descriptor;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.github.extension.status.GitHubStatusResultSource;
+import org.kohsuke.github.GHCommitState;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+
+import static hudson.model.Result.SUCCESS;
+import static hudson.model.Result.UNSTABLE;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+public class DefaultStatusResultSource extends GitHubStatusResultSource {
+
+    @DataBoundConstructor
+    public DefaultStatusResultSource() {
+    }
+
+    @Override
+    public StatusResult get(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener) {
+        Result result = run.getResult();
+
+        // We do not use `build.getDurationString()` because it appends 'and counting' (build is still running)
+        String duration = Util.getTimeSpanString(System.currentTimeMillis() - run.getTimeInMillis());
+
+        if (result == null) { // Build is ongoing
+            return new GitHubStatusResultSource.StatusResult(
+                    GHCommitState.PENDING,
+                    Messages.CommitNotifier_Pending(run.getDisplayName())
+            );
+        } else if (result.isBetterOrEqualTo(SUCCESS)) {
+            return new GitHubStatusResultSource.StatusResult(
+                    GHCommitState.SUCCESS,
+                    Messages.CommitNotifier_Success(run.getDisplayName(), duration)
+            );
+        } else if (result.isBetterOrEqualTo(UNSTABLE)) {
+            return new GitHubStatusResultSource.StatusResult(
+                    GHCommitState.FAILURE,
+                    Messages.CommitNotifier_Unstable(run.getDisplayName(), duration)
+            );
+        } else {
+            return new GitHubStatusResultSource.StatusResult(
+                    GHCommitState.ERROR,
+                    Messages.CommitNotifier_Failed(run.getDisplayName(), duration)
+            );
+        }
+    }
+
+    @Extension
+    public static class DefaultResultSourceDescriptor extends Descriptor<GitHubStatusResultSource> {
+        @Override
+        public String getDisplayName() {
+            return "One of default messages and statuses";
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/github/status/sources/ManuallyEnteredCommitContextSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/sources/ManuallyEnteredCommitContextSource.java
@@ -1,0 +1,35 @@
+package org.jenkinsci.plugins.github.status.sources;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.github.extension.status.GitHubStatusContextSource;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+public class ManuallyEnteredCommitContextSource extends GitHubStatusContextSource {
+    private String context;
+    
+    @DataBoundConstructor
+    public ManuallyEnteredCommitContextSource(String context) {
+        this.context = context;
+    }
+
+    @Override
+    public String context(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener) {
+        return context;
+    }
+
+    @Extension
+    public static class ManuallyEnteredCommitContextSourceDescriptor extends Descriptor<GitHubStatusContextSource> {
+        @Override
+        public String getDisplayName() {
+            return "Manually entered context name";
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/github/status/sources/ManuallyEnteredShaSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/sources/ManuallyEnteredShaSource.java
@@ -12,7 +12,10 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 
 /**
+ * Allows to enter sha manually
+ *
  * @author lanwen (Merkushev Kirill)
+ * @since 1.19.0
  */
 public class ManuallyEnteredShaSource extends GitHubCommitShaSource {
 
@@ -27,6 +30,9 @@ public class ManuallyEnteredShaSource extends GitHubCommitShaSource {
         return sha;
     }
 
+    /**
+     * Expands env vars and token macro in entered sha
+     */
     @Override
     public String get(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener) throws IOException, InterruptedException {
         return new ExpandableMessage(sha).expandAll(run, listener);

--- a/src/main/java/org/jenkinsci/plugins/github/status/sources/ManuallyEnteredShaSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/sources/ManuallyEnteredShaSource.java
@@ -1,0 +1,42 @@
+package org.jenkinsci.plugins.github.status.sources;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.github.common.ExpandableMessage;
+import org.jenkinsci.plugins.github.extension.status.GitHubCommitShaSource;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+public class ManuallyEnteredShaSource extends GitHubCommitShaSource {
+
+    private String sha;
+
+    @DataBoundConstructor
+    public ManuallyEnteredShaSource(String sha) {
+        this.sha = sha;
+    }
+
+    public String getSha() {
+        return sha;
+    }
+
+    @Override
+    public String get(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener) throws IOException, InterruptedException {
+        return new ExpandableMessage(sha).expandAll(run, listener);
+    }
+
+    @Extension
+    public static class ManuallyEnteredShaSourceDescriptor extends Descriptor<GitHubCommitShaSource> {
+        @Override
+        public String getDisplayName() {
+            return "Manually entered SHA";
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/github/status/sources/misc/AnyBuildResult.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/sources/misc/AnyBuildResult.java
@@ -3,12 +3,16 @@ package org.jenkinsci.plugins.github.status.sources.misc;
 import hudson.Extension;
 import hudson.model.Run;
 import org.jenkinsci.plugins.github.extension.status.misc.ConditionalResult;
+import org.kohsuke.github.GHCommitState;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.Nonnull;
 
 /**
+ * Allows to set state in any case
+ *
  * @author lanwen (Merkushev Kirill)
+ * @since 1.19.0
  */
 public class AnyBuildResult extends ConditionalResult {
 
@@ -16,16 +20,32 @@ public class AnyBuildResult extends ConditionalResult {
     public AnyBuildResult() {
     }
 
+    /**
+     * @return true in any case
+     */
     @Override
     public boolean matches(@Nonnull Run<?, ?> run) {
         return true;
+    }
+
+    /**
+     * @param state state to set
+     * @param msg   message to set. Can contain env vars
+     *
+     * @return new instance of this conditional result
+     */
+    public static AnyBuildResult onAnyResult(GHCommitState state, String msg) {
+        AnyBuildResult cond = new AnyBuildResult();
+        cond.setState(state.name());
+        cond.setMessage(msg);
+        return cond;
     }
 
     @Extension
     public static class AnyBuildResultDescriptor extends ConditionalResultDescriptor {
         @Override
         public String getDisplayName() {
-            return "Result ANY";
+            return "result ANY";
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/github/status/sources/misc/AnyBuildResult.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/sources/misc/AnyBuildResult.java
@@ -1,0 +1,31 @@
+package org.jenkinsci.plugins.github.status.sources.misc;
+
+import hudson.Extension;
+import hudson.model.Run;
+import org.jenkinsci.plugins.github.extension.status.misc.ConditionalResult;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+public class AnyBuildResult extends ConditionalResult {
+
+    @DataBoundConstructor
+    public AnyBuildResult() {
+    }
+
+    @Override
+    public boolean matches(@Nonnull Run<?, ?> run) {
+        return true;
+    }
+
+    @Extension
+    public static class AnyBuildResultDescriptor extends ConditionalResultDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Result ANY";
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/github/status/sources/misc/BetterThanOrEqualBuildResult.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/sources/misc/BetterThanOrEqualBuildResult.java
@@ -69,11 +69,7 @@ public class BetterThanOrEqualBuildResult extends ConditionalResult {
     @Extension
     public static class BetterThanOrEqualBuildResultDescriptor extends ConditionalResultDescriptor {
 
-        private static final Result[] SUPPORTED_RESULTS = {
-                SUCCESS,
-                UNSTABLE,
-                FAILURE,
-        };
+        private static final Result[] SUPPORTED_RESULTS = {SUCCESS, UNSTABLE, FAILURE};
 
         @Override
         public String getDisplayName() {

--- a/src/main/java/org/jenkinsci/plugins/github/status/sources/misc/BetterThanOrEqualBuildResult.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/sources/misc/BetterThanOrEqualBuildResult.java
@@ -5,6 +5,7 @@ import hudson.model.Result;
 import hudson.model.Run;
 import hudson.util.ListBoxModel;
 import org.jenkinsci.plugins.github.extension.status.misc.ConditionalResult;
+import org.kohsuke.github.GHCommitState;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -18,7 +19,10 @@ import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 
 /**
+ * if run result better than or equal to selected
+ *
  * @author lanwen (Merkushev Kirill)
+ * @since 1.19.0
  */
 public class BetterThanOrEqualBuildResult extends ConditionalResult {
 
@@ -37,13 +41,34 @@ public class BetterThanOrEqualBuildResult extends ConditionalResult {
         return result;
     }
 
+    /**
+     * @return matches if run result better than or equal to selected
+     */
     @Override
     public boolean matches(@Nonnull Run<?, ?> run) {
         return defaultIfNull(run.getResult(), Result.NOT_BUILT).isBetterOrEqualTo(fromString(trimToEmpty(result)));
     }
 
+    /**
+     * Convenient way to reuse logic of checking for the build status
+     *
+     * @param result to check against
+     * @param state  state to set
+     * @param msg    message to set. Can contain env vars
+     *
+     * @return new instance of this conditional result
+     */
+    public static BetterThanOrEqualBuildResult betterThanOrEqualTo(Result result, GHCommitState state, String msg) {
+        BetterThanOrEqualBuildResult conditional = new BetterThanOrEqualBuildResult();
+        conditional.setResult(result.toString());
+        conditional.setState(state.name());
+        conditional.setMessage(msg);
+        return conditional;
+    }
+
     @Extension
     public static class BetterThanOrEqualBuildResultDescriptor extends ConditionalResultDescriptor {
+
         private static final Result[] SUPPORTED_RESULTS = {
                 SUCCESS,
                 UNSTABLE,
@@ -52,7 +77,7 @@ public class BetterThanOrEqualBuildResult extends ConditionalResult {
 
         @Override
         public String getDisplayName() {
-            return "Result better than or equal to";
+            return "result better than or equal to";
         }
 
         @SuppressWarnings("unused")

--- a/src/main/resources/com/cloudbees/jenkins/GitHubCommitNotifier/help.html
+++ b/src/main/resources/com/cloudbees/jenkins/GitHubCommitNotifier/help.html
@@ -1,0 +1,5 @@
+<div>
+    This notifier will set GH commit status.
+    <b>This step is DEPRECATED and will be migrated to new step in one of the next major plugin releases.</b> <br/>
+    Please refer to new universal step.
+</div>

--- a/src/main/resources/com/cloudbees/jenkins/Messages.properties
+++ b/src/main/resources/com/cloudbees/jenkins/Messages.properties
@@ -3,5 +3,5 @@ CommitNotifier.Unstable=Build {0} found unstable in {1}
 CommitNotifier.Failed=Build {0} failed in {1}
 CommitNotifier.Pending=Build {0} in progress...
 GitHubCommitNotifier.SettingCommitStatus=Setting commit status on GitHub for {0}
-GitHubCommitNotifier.DisplayName=Set build status on GitHub commit
+GitHubCommitNotifier.DisplayName=Set build status on GitHub commit [deprecated]
 GitHubSetCommitStatusBuilder.DisplayName=Set build status to "pending" on GitHub commit

--- a/src/main/resources/org/jenkinsci/plugins/github/extension/status/misc/ConditionalResult/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/extension/status/misc/ConditionalResult/config.groovy
@@ -1,0 +1,12 @@
+package org.jenkinsci.plugins.github.extension.status.misc.ConditionalResult
+
+
+def f = namespace(lib.FormTagLib);
+
+f.entry(title: _('Status'), field: 'status') {
+    f.select()
+}
+
+f.entry(title: _('Message'), field: 'message') {
+    f.textbox()
+}

--- a/src/main/resources/org/jenkinsci/plugins/github/extension/status/misc/ConditionalResult/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/extension/status/misc/ConditionalResult/config.groovy
@@ -3,7 +3,7 @@ package org.jenkinsci.plugins.github.extension.status.misc.ConditionalResult
 
 def f = namespace(lib.FormTagLib);
 
-f.entry(title: _('Status'), field: 'status') {
+f.entry(title: _('Status'), field: 'state') {
     f.select()
 }
 

--- a/src/main/resources/org/jenkinsci/plugins/github/status/GitHubCommitStatusSetter/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/GitHubCommitStatusSetter/config.groovy
@@ -27,7 +27,7 @@ f.advanced {
                 f.hetero_list(items: CollectionUtils.isEmpty(instance?.errorHandlers)
                         ? []
                         : instance.errorHandlers,
-                        addCaption: 'Add handler',
+                        addCaption: 'Add error handler',
                         name: 'errorHandlers',
                         oneEach: true, hasHeader: true, descriptors: StatusErrorHandler.all())
             }

--- a/src/main/resources/org/jenkinsci/plugins/github/status/GitHubCommitStatusSetter/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/GitHubCommitStatusSetter/config.groovy
@@ -1,0 +1,36 @@
+package org.jenkinsci.plugins.github.status.GitHubCommitStatusSetter
+
+import org.apache.commons.collections.CollectionUtils
+import org.jenkinsci.plugins.github.extension.status.StatusErrorHandler
+
+
+def f = namespace(lib.FormTagLib);
+
+f.section(title: _('Where:')) {
+    f.dropdownDescriptorSelector(title: _('Commit SHA: '), field: 'commitShaSource')
+    f.dropdownDescriptorSelector(title: _('Repositories: '), field: 'reposSource')
+}
+
+f.section(title: _('What:')) {
+    f.dropdownDescriptorSelector(title: _('Commit context: '), field: 'contextSource')
+    f.dropdownDescriptorSelector(title: _('Status result: '), field: 'statusResultSource')
+}
+
+f.advanced {
+    f.section(title: _('Advanced:')) {
+        f.optionalBlock(
+                checked: CollectionUtils.isNotEmpty(instance?.errorHandlers),
+                inline: true,
+                name: 'errorHandling',
+                title: 'Handle errors') {
+            f.block {
+                f.hetero_list(items: CollectionUtils.isEmpty(instance?.errorHandlers)
+                        ? []
+                        : instance.errorHandlers,
+                        addCaption: 'Add handler',
+                        name: 'errorHandlers',
+                        oneEach: true, hasHeader: true, descriptors: StatusErrorHandler.all())
+            }
+        }
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/github/status/GitHubCommitStatusSetter/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/GitHubCommitStatusSetter/help.html
@@ -1,0 +1,3 @@
+<div>
+    Using GitHub status api sets status of the commit
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/github/status/err/ChangingBuildStatusErrorHandler/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/err/ChangingBuildStatusErrorHandler/config.groovy
@@ -1,0 +1,7 @@
+package org.jenkinsci.plugins.github.status.err.ChangingBuildStatusErrorHandler
+
+def f = namespace(lib.FormTagLib);
+
+f.entry(title: _('Result on failure'), field: 'result') {
+    f.select()
+}

--- a/src/main/resources/org/jenkinsci/plugins/github/status/err/ShallowAnyErrorHandler/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/err/ShallowAnyErrorHandler/config.groovy
@@ -1,0 +1,7 @@
+package org.jenkinsci.plugins.github.status.err.ShallowAnyErrorHandler
+
+
+def f = namespace(lib.FormTagLib);
+
+f.helpLink(url: descriptor.getHelpFile())
+f.helpArea()

--- a/src/main/resources/org/jenkinsci/plugins/github/status/sources/AnyDefinedRepositorySource/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/sources/AnyDefinedRepositorySource/config.groovy
@@ -1,0 +1,7 @@
+package org.jenkinsci.plugins.github.status.sources.AnyDefinedRepositorySource
+
+
+def f = namespace(lib.FormTagLib);
+
+f.helpLink(url: descriptor.getHelpFile())
+f.helpArea()

--- a/src/main/resources/org/jenkinsci/plugins/github/status/sources/AnyDefinedRepositorySource/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/sources/AnyDefinedRepositorySource/help.html
@@ -1,0 +1,3 @@
+<div>
+    Any repository provided by the programmatic contributors list
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/github/status/sources/BuildDataRevisionShaSource/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/sources/BuildDataRevisionShaSource/config.groovy
@@ -1,0 +1,7 @@
+package org.jenkinsci.plugins.github.status.sources.BuildDataRevisionShaSource
+
+
+def f = namespace(lib.FormTagLib);
+
+f.helpLink(url: descriptor.getHelpFile())
+f.helpArea()

--- a/src/main/resources/org/jenkinsci/plugins/github/status/sources/BuildDataRevisionShaSource/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/sources/BuildDataRevisionShaSource/help.html
@@ -1,0 +1,3 @@
+<div>
+    Uses data-action (located at ${build.url}/git/) to determine actual SHA
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/github/status/sources/ConditionalStatusResultSource/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/sources/ConditionalStatusResultSource/config.groovy
@@ -1,0 +1,15 @@
+package org.jenkinsci.plugins.github.status.sources.ConditionalStatusResultSource
+
+import org.apache.commons.collections.CollectionUtils
+import org.jenkinsci.plugins.github.extension.status.misc.ConditionalResult.ConditionalResultDescriptor;
+
+def f = namespace(lib.FormTagLib);
+
+f.block {
+    f.hetero_list(items: CollectionUtils.isEmpty(instance?.results)
+            ? []
+            : instance.results,
+            addCaption: 'If build',
+            name: 'results',
+            oneEach: false, hasHeader: true, descriptors: ConditionalResultDescriptor.all())
+}

--- a/src/main/resources/org/jenkinsci/plugins/github/status/sources/ConditionalStatusResultSource/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/sources/ConditionalStatusResultSource/config.groovy
@@ -5,11 +5,14 @@ import org.jenkinsci.plugins.github.extension.status.misc.ConditionalResult.Cond
 
 def f = namespace(lib.FormTagLib);
 
+f.helpLink(url: descriptor.getHelpFile())
+f.helpArea()
+
 f.block {
     f.hetero_list(items: CollectionUtils.isEmpty(instance?.results)
             ? []
             : instance.results,
-            addCaption: 'If build',
+            addCaption: 'If Run',
             name: 'results',
             oneEach: false, hasHeader: true, descriptors: ConditionalResultDescriptor.all())
 }

--- a/src/main/resources/org/jenkinsci/plugins/github/status/sources/ConditionalStatusResultSource/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/sources/ConditionalStatusResultSource/help.html
@@ -1,0 +1,4 @@
+<div>
+    You can define in which cases you want to publish exact state and message for the commit. You can define multiply cases. 
+    First match (starting from top) wins. If no one matches, <i>PENDING</i> status + warn message will be used.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/github/status/sources/DefaultCommitContextSource/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/sources/DefaultCommitContextSource/config.groovy
@@ -1,0 +1,7 @@
+package org.jenkinsci.plugins.github.status.sources.DefaultCommitContextSource
+
+
+def f = namespace(lib.FormTagLib);
+
+f.helpLink(url: descriptor.getHelpFile())
+f.helpArea()

--- a/src/main/resources/org/jenkinsci/plugins/github/status/sources/DefaultCommitContextSource/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/sources/DefaultCommitContextSource/help.html
@@ -1,0 +1,3 @@
+<div>
+    Uses display name property defined in "Github project property" with fallback to job name.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/github/status/sources/DefaultStatusResultSource/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/sources/DefaultStatusResultSource/config.groovy
@@ -1,0 +1,7 @@
+package org.jenkinsci.plugins.github.status.sources.DefaultStatusResultSource
+
+
+def f = namespace(lib.FormTagLib);
+
+f.helpLink(url: descriptor.getHelpFile())
+f.helpArea()

--- a/src/main/resources/org/jenkinsci/plugins/github/status/sources/DefaultStatusResultSource/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/sources/DefaultStatusResultSource/help.html
@@ -1,0 +1,3 @@
+<div>
+    Writes simple message about build result and duration
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/github/status/sources/ManuallyEnteredCommitContextSource/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/sources/ManuallyEnteredCommitContextSource/config.groovy
@@ -1,0 +1,8 @@
+package org.jenkinsci.plugins.github.status.sources.ManuallyEnteredCommitContextSource
+
+
+def f = namespace(lib.FormTagLib);
+
+f.entry(title: _('Context name'), field: 'context') {
+    f.textbox()
+}

--- a/src/main/resources/org/jenkinsci/plugins/github/status/sources/ManuallyEnteredCommitContextSource/help-context.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/sources/ManuallyEnteredCommitContextSource/help-context.html
@@ -1,0 +1,3 @@
+<div>
+    Allows env vars and token macro 
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/github/status/sources/ManuallyEnteredCommitContextSource/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/sources/ManuallyEnteredCommitContextSource/help.html
@@ -1,0 +1,3 @@
+<div>
+    You can define context name manually
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/github/status/sources/ManuallyEnteredShaSource/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/sources/ManuallyEnteredShaSource/config.groovy
@@ -1,0 +1,8 @@
+package org.jenkinsci.plugins.github.status.sources.ManuallyEnteredShaSource
+
+
+def f = namespace(lib.FormTagLib);
+
+f.entry(title: _('SHA'), field: 'sha') {
+    f.textbox()
+}

--- a/src/main/resources/org/jenkinsci/plugins/github/status/sources/ManuallyEnteredShaSource/help-sha.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/sources/ManuallyEnteredShaSource/help-sha.html
@@ -1,0 +1,3 @@
+<div>
+    Allows env vars and token macro
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/github/status/sources/ManuallyEnteredShaSource/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/sources/ManuallyEnteredShaSource/help.html
@@ -1,0 +1,3 @@
+<div>
+    Allows to define commit sha manually
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/github/status/sources/misc/BetterThanOrEqualBuildResult/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/sources/misc/BetterThanOrEqualBuildResult/config.groovy
@@ -1,0 +1,17 @@
+package org.jenkinsci.plugins.github.status.sources.misc.BetterThanOrEqualBuildResult
+
+
+def f = namespace(lib.FormTagLib);
+
+
+f.entry(title: _('Build result better than or equal to'), field: 'result') {
+    f.select()
+}
+
+f.entry(title: _('Status'), field: 'status') {
+    f.select()
+}
+
+f.entry(title: _('Message'), field: 'message') {
+    f.textbox()
+}

--- a/src/main/resources/org/jenkinsci/plugins/github/status/sources/misc/BetterThanOrEqualBuildResult/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/sources/misc/BetterThanOrEqualBuildResult/config.groovy
@@ -8,7 +8,7 @@ f.entry(title: _('Build result better than or equal to'), field: 'result') {
     f.select()
 }
 
-f.entry(title: _('Status'), field: 'status') {
+f.entry(title: _('Status'), field: 'state') {
     f.select()
 }
 

--- a/src/main/resources/org/jenkinsci/plugins/github/status/sources/misc/BetterThanOrEqualBuildResult/help-message.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/status/sources/misc/BetterThanOrEqualBuildResult/help-message.html
@@ -1,0 +1,3 @@
+<div>
+    Allows env vars and token macro
+</div>

--- a/src/test/java/com/cloudbees/jenkins/GitHubSetCommitStatusBuilderTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GitHubSetCommitStatusBuilderTest.java
@@ -84,12 +84,11 @@ public class GitHubSetCommitStatusBuilderTest {
 
     @Test
     @Issue("JENKINS-23641")
-    public void testNoBuildData() throws Exception {
+    public void shouldIgnoreIfNoBuildData() throws Exception {
         FreeStyleProject prj = jRule.createFreeStyleProject("23641_noBuildData");
         prj.getBuildersList().add(new GitHubSetCommitStatusBuilder());
         Build b = prj.scheduleBuild2(0).get();
-        jRule.assertBuildStatus(Result.FAILURE, b);
-        jRule.assertLogContains(org.jenkinsci.plugins.github.util.Messages.BuildDataHelper_NoBuildDataError(), b);
+        jRule.assertBuildStatus(Result.SUCCESS, b);
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/github/common/CombineErrorHandlerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/common/CombineErrorHandlerTest.java
@@ -1,0 +1,96 @@
+package org.jenkinsci.plugins.github.common;
+
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.github.status.err.ChangingBuildStatusErrorHandler;
+import org.jenkinsci.plugins.github.status.err.ShallowAnyErrorHandler;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.is;
+import static org.jenkinsci.plugins.github.common.CombineErrorHandler.errorHandling;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CombineErrorHandlerTest {
+
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private Run run;
+
+    @Mock
+    private TaskListener listener;
+
+    @Rule
+    public ExpectedException exc = ExpectedException.none();
+
+    @Test
+    public void shouldRethrowExceptionIfNoMatch() throws Exception {
+        exc.expect(CombineErrorHandler.ErrorHandlingException.class);
+
+        errorHandling().handle(new RuntimeException(), run, listener);
+    }
+
+    @Test
+    public void shouldRethrowExceptionIfNullHandlersList() throws Exception {
+        exc.expect(CombineErrorHandler.ErrorHandlingException.class);
+
+        errorHandling().withHandlers(null).handle(new RuntimeException(), run, listener);
+    }
+
+    @Test
+    public void shouldHandleExceptionsWithHandler() throws Exception {
+        boolean handled = errorHandling()
+                .withHandlers(Collections.singletonList(new ShallowAnyErrorHandler()))
+                .handle(new RuntimeException(), run, listener);
+
+        assertThat("handling", handled, is(true));
+    }
+
+    @Test
+    public void shouldRethrowExceptionIfExceptionInside() throws Exception {
+        exc.expect(CombineErrorHandler.ErrorHandlingException.class);
+
+        errorHandling()
+                .withHandlers(Collections.singletonList(
+                        new ErrorHandler() {
+                            @Override
+                            public boolean handle(Exception e, @Nonnull Run<?, ?> run, @Nonnull TaskListener listener) {
+                                throw new RuntimeException("wow");
+                            }
+                        }
+                ))
+                .handle(new RuntimeException(), run, listener);
+    }
+
+    @Test
+    public void shouldHandleExceptionWithFirstMatchAndSetStatus() throws Exception {
+        boolean handled = errorHandling()
+                .withHandlers(asList(
+                        new ChangingBuildStatusErrorHandler(Result.FAILURE.toString()),
+                        new ShallowAnyErrorHandler()
+                ))
+                .handle(new RuntimeException(), run, listener);
+
+        assertThat("handling", handled, is(true));
+
+        verify(run).setResult(Result.FAILURE);
+        verify(run, times(2)).getParent();
+        verifyNoMoreInteractions(run);
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/github/status/GitHubCommitStatusSetterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/status/GitHubCommitStatusSetterTest.java
@@ -1,0 +1,134 @@
+package org.jenkinsci.plugins.github.status;
+
+import com.cloudbees.jenkins.GitHubSetCommitStatusBuilder;
+import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.plugins.git.Revision;
+import hudson.plugins.git.util.BuildData;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jgit.lib.ObjectId;
+import org.jenkinsci.plugins.github.config.GitHubPluginConfig;
+import org.jenkinsci.plugins.github.extension.status.StatusErrorHandler;
+import org.jenkinsci.plugins.github.status.err.ChangingBuildStatusErrorHandler;
+import org.jenkinsci.plugins.github.status.sources.AnyDefinedRepositorySource;
+import org.jenkinsci.plugins.github.status.sources.BuildDataRevisionShaSource;
+import org.jenkinsci.plugins.github.status.sources.DefaultCommitContextSource;
+import org.jenkinsci.plugins.github.status.sources.DefaultStatusResultSource;
+import org.jenkinsci.plugins.github.test.GHMockRule;
+import org.jenkinsci.plugins.github.test.GHMockRule.FixedGHRepoNameTestContributor;
+import org.jenkinsci.plugins.github.test.InjectJenkinsMembersRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestBuilder;
+import org.jvnet.hudson.test.TestExtension;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.inject.Inject;
+import java.util.Collections;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link GitHubSetCommitStatusBuilder}.
+ *
+ * @author Oleg Nenashev <o.v.nenashev@gmail.com>
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class GitHubCommitStatusSetterTest {
+
+    public static final String SOME_SHA = StringUtils.repeat("f", 40);
+
+    @Mock
+    public BuildData data;
+
+    @Mock
+    public Revision rev;
+
+    @Inject
+    public GitHubPluginConfig config;
+
+    public JenkinsRule jRule = new JenkinsRule();
+
+    @Rule
+    public RuleChain chain = RuleChain.outerRule(jRule).around(new InjectJenkinsMembersRule(jRule, this));
+
+    @Rule
+    public GHMockRule github = new GHMockRule(
+            new WireMockRule(
+                    wireMockConfig().dynamicPort().notifier(new Slf4jNotifier(true))
+            ))
+            .stubUser()
+            .stubRepo()
+            .stubStatuses();
+
+    @Rule
+    public ExternalResource prep = new ExternalResource() {
+        @Override
+        protected void before() throws Throwable {
+            when(data.getLastBuiltRevision()).thenReturn(rev);
+            data.lastBuild = new hudson.plugins.git.util.Build(rev, rev, 0, Result.SUCCESS);
+            when(rev.getSha1()).thenReturn(ObjectId.fromString(SOME_SHA));
+        }
+    };
+
+
+    @Test
+    public void shouldSetGHCommitStatus() throws Exception {
+        config.getConfigs().add(github.serverConfig());
+        FreeStyleProject prj = jRule.createFreeStyleProject();
+
+        GitHubCommitStatusSetter statusSetter = new GitHubCommitStatusSetter();
+        statusSetter.setCommitShaSource(new BuildDataRevisionShaSource());
+        statusSetter.setContextSource(new DefaultCommitContextSource());
+        statusSetter.setReposSource(new AnyDefinedRepositorySource());
+        statusSetter.setStatusResultSource(new DefaultStatusResultSource());
+
+
+        prj.getBuildersList().add(new TestBuilder() {
+            @Override
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
+                build.addAction(data);
+                return true;
+            }
+        });
+
+        prj.getPublishersList().add(statusSetter);
+        prj.scheduleBuild2(0).get();
+
+        github.service().verify(1, postRequestedFor(urlPathMatching(".*/" + SOME_SHA)));
+    }
+
+    @Test
+    public void shouldHandleError() throws Exception {
+        FreeStyleProject prj = jRule.createFreeStyleProject();
+
+        GitHubCommitStatusSetter statusSetter = new GitHubCommitStatusSetter();
+        statusSetter.setCommitShaSource(new BuildDataRevisionShaSource());
+        statusSetter.setErrorHandlers(Collections.<StatusErrorHandler>singletonList(
+                new ChangingBuildStatusErrorHandler(Result.UNSTABLE.toString())
+        ));
+        statusSetter.setReposSource(new AnyDefinedRepositorySource());
+        statusSetter.setStatusResultSource(new DefaultStatusResultSource());
+
+        prj.getPublishersList().add(statusSetter);
+        FreeStyleBuild build = prj.scheduleBuild2(0).get();
+        jRule.assertBuildStatus(Result.UNSTABLE, build);
+    }
+
+    @TestExtension
+    public static final FixedGHRepoNameTestContributor CONTRIBUTOR = new FixedGHRepoNameTestContributor();
+}

--- a/src/test/java/org/jenkinsci/plugins/github/status/err/ErrorHandlersTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/status/err/ErrorHandlersTest.java
@@ -1,0 +1,53 @@
+package org.jenkinsci.plugins.github.status.err;
+
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ErrorHandlersTest {
+
+    @Mock
+    private Run run;
+
+    @Mock
+    private TaskListener listener;
+
+    @Test
+    public void shouldSetFailureResultStatus() throws Exception {
+        boolean handled = new ChangingBuildStatusErrorHandler(Result.FAILURE.toString())
+                .handle(new RuntimeException(), run, listener);
+
+        verify(run).setResult(Result.FAILURE);
+        assertThat("handling", handled, is(true));
+    }
+
+    @Test
+    public void shouldSetFailureResultStatusOnUnknownSetup() throws Exception {
+        boolean handled = new ChangingBuildStatusErrorHandler("")
+                .handle(new RuntimeException(), run, listener);
+
+        verify(run).setResult(Result.FAILURE);
+        assertThat("handling", handled, is(true));
+    }
+
+    @Test
+    public void shouldHandleAndDoNothing() throws Exception {
+        boolean handled = new ShallowAnyErrorHandler().handle(new RuntimeException(), run, listener);
+        assertThat("handling", handled, is(true));
+
+        Mockito.verifyNoMoreInteractions(run);
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/github/status/sources/ConditionalStatusResultSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/status/sources/ConditionalStatusResultSourceTest.java
@@ -1,0 +1,82 @@
+package org.jenkinsci.plugins.github.status.sources;
+
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.github.extension.status.GitHubStatusResultSource;
+import org.jenkinsci.plugins.github.extension.status.misc.ConditionalResult;
+import org.jenkinsci.plugins.github.status.sources.misc.AnyBuildResult;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kohsuke.github.GHCommitState;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Collections;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.jenkinsci.plugins.github.status.sources.misc.BetterThanOrEqualBuildResult.betterThanOrEqualTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ConditionalStatusResultSourceTest {
+
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private Run run;
+
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private TaskListener listener;
+
+    @Test
+    public void shouldReturnPendingByDefault() throws Exception {
+        GitHubStatusResultSource.StatusResult res = new ConditionalStatusResultSource(null).get(run, listener);
+
+        assertThat("state", res.getState(), is(GHCommitState.PENDING));
+        assertThat("msg", res.getMsg(), notNullValue());
+    }
+
+    @Test
+    public void shouldReturnPendingIfNoMatch() throws Exception {
+        when(run.getResult()).thenReturn(Result.FAILURE);
+
+        GitHubStatusResultSource.StatusResult res = new ConditionalStatusResultSource(
+                Collections.<ConditionalResult>singletonList(
+                        betterThanOrEqualTo(Result.SUCCESS, GHCommitState.SUCCESS, "2")
+                ))
+                .get(run, listener);
+
+        assertThat("state", res.getState(), is(GHCommitState.PENDING));
+        assertThat("msg", res.getMsg(), notNullValue());
+    }
+
+    @Test
+    public void shouldReturnFirstMatch() throws Exception {
+        GitHubStatusResultSource.StatusResult res = new ConditionalStatusResultSource(asList(
+                AnyBuildResult.onAnyResult(GHCommitState.FAILURE, "1"),
+                betterThanOrEqualTo(Result.SUCCESS, GHCommitState.SUCCESS, "2")
+        )).get(run, listener);
+
+        assertThat("state", res.getState(), is(GHCommitState.FAILURE));
+        assertThat("msg", res.getMsg(), notNullValue());
+    }
+
+    @Test
+    public void shouldReturnFirstMatch2() throws Exception {
+        when(run.getResult()).thenReturn(Result.SUCCESS);
+
+        GitHubStatusResultSource.StatusResult res = new ConditionalStatusResultSource(asList(
+                betterThanOrEqualTo(Result.SUCCESS, GHCommitState.SUCCESS, "2"),
+                AnyBuildResult.onAnyResult(GHCommitState.FAILURE, "1")
+        )).get(run, listener);
+
+        assertThat("state", res.getState(), is(GHCommitState.SUCCESS));
+        assertThat("msg", res.getMsg(), notNullValue());
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/github/status/sources/DefaultStatusResultSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/status/sources/DefaultStatusResultSourceTest.java
@@ -1,0 +1,57 @@
+package org.jenkinsci.plugins.github.status.sources;
+
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.github.extension.status.GitHubStatusResultSource;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kohsuke.github.GHCommitState;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+@RunWith(DataProviderRunner.class)
+public class DefaultStatusResultSourceTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private Run run;
+
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private TaskListener listener;
+
+    @DataProvider
+    public static Object[][] results() {
+        return new Object[][]{
+                {Result.SUCCESS, GHCommitState.SUCCESS},
+                {Result.UNSTABLE, GHCommitState.FAILURE},
+                {Result.FAILURE, GHCommitState.ERROR},
+                {null, GHCommitState.PENDING},
+        };
+    }
+
+    @Test
+    @UseDataProvider("results")
+    public void shouldReturnConditionalResult(Result actual, GHCommitState expected) throws Exception {
+        when(run.getResult()).thenReturn(actual);
+
+        GitHubStatusResultSource.StatusResult result = new DefaultStatusResultSource().get(run, listener);
+        assertThat("state", result.getState(), is(expected));
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/github/status/sources/ManuallyEnteredSourcesTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/status/sources/ManuallyEnteredSourcesTest.java
@@ -1,0 +1,51 @@
+package org.jenkinsci.plugins.github.status.sources;
+
+import hudson.EnvVars;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ManuallyEnteredSourcesTest {
+
+    public static final String EXPANDED = "expanded";
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private Run run;
+
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private TaskListener listener;
+
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private EnvVars env;
+
+
+    @Test
+    public void shouldExpandContext() throws Exception {
+        when(run.getEnvironment(listener)).thenReturn(env);
+        when(env.expand(Matchers.anyString())).thenReturn(EXPANDED);
+
+        String context = new ManuallyEnteredCommitContextSource("").context(run, listener);
+        assertThat(context, equalTo(EXPANDED));
+    }
+
+    @Test
+    public void shouldExpandSha() throws Exception {
+        when(run.getEnvironment(listener)).thenReturn(env);
+        when(env.expand(Matchers.anyString())).thenReturn(EXPANDED);
+
+        String context = new ManuallyEnteredShaSource("").get(run, listener);
+        assertThat(context, equalTo(EXPANDED));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/github/status/sources/misc/AnyBuildResultTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/status/sources/misc/AnyBuildResultTest.java
@@ -1,0 +1,30 @@
+package org.jenkinsci.plugins.github.status.sources.misc;
+
+import hudson.model.Run;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kohsuke.github.GHCommitState;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AnyBuildResultTest {
+
+    @Mock
+    private Run run;
+
+    @Test
+    public void shouldMatchEveryTime() throws Exception {
+        boolean matches = AnyBuildResult.onAnyResult(GHCommitState.ERROR, "").matches(run);
+        
+        assertTrue("matching", matches);
+        verifyNoMoreInteractions(run);
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/github/status/sources/misc/BetterThanOrEqualBuildResultTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/status/sources/misc/BetterThanOrEqualBuildResultTest.java
@@ -1,0 +1,55 @@
+package org.jenkinsci.plugins.github.status.sources.misc;
+
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import hudson.model.Result;
+import hudson.model.Run;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kohsuke.github.GHCommitState;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.hamcrest.Matchers.is;
+import static org.jenkinsci.plugins.github.status.sources.misc.BetterThanOrEqualBuildResult.betterThanOrEqualTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+@RunWith(DataProviderRunner.class)
+public class BetterThanOrEqualBuildResultTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private Run run;
+
+    @DataProvider
+    public static Object[][] results() {
+        return new Object[][]{
+                {Result.SUCCESS, Result.SUCCESS, true},
+                {Result.UNSTABLE, Result.UNSTABLE, true},
+                {Result.FAILURE, Result.FAILURE, true},
+                {Result.FAILURE, Result.UNSTABLE, true},
+                {Result.FAILURE, Result.SUCCESS, true},
+                {Result.SUCCESS, Result.FAILURE, false},
+                {Result.SUCCESS, Result.UNSTABLE, false},
+                {Result.UNSTABLE, Result.FAILURE, false},
+        };
+    }
+
+    @Test
+    @UseDataProvider("results")
+    public void shouldMatch(Result defined, Result real, boolean expect) throws Exception {
+        Mockito.when(run.getResult()).thenReturn(real);
+
+        boolean matched = betterThanOrEqualTo(defined, GHCommitState.FAILURE, "").matches(run);
+        assertThat("matching", matched, is(expect));
+    }
+}


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1964214/14590322/0c0a4f94-0500-11e6-9c91-fa5f97ed922a.png)

also will be:
- [ ] ~~extended pipeline dsl~~ (require core dep updating, will be in next pr)
- [x] docs + helps for new classes
- [x] deprecation of old setters
- [x] manual fields to enter sha, message, etc...
- [x] tests

linked with: 
- [JENKINS-34144](https://issues.jenkins-ci.org/browse/JENKINS-34144)
- [JENKINS-33371](https://issues.jenkins-ci.org/browse/JENKINS-33371)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/119)
<!-- Reviewable:end -->
