### PR TITLE
Improved logging format

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
@@ -108,7 +108,6 @@ public class GitHubPushTrigger extends Trigger<Job<?, ?>> implements GitHubTrigg
 
             public void run() {
                 if (runPolling()) {
-                    String name = " #" + job.getNextBuildNumber();
                     GitHubPushCause cause;
                     try {
                         cause = new GitHubPushCause(getLogFile(), pushBy);
@@ -117,9 +116,9 @@ public class GitHubPushTrigger extends Trigger<Job<?, ?>> implements GitHubTrigg
                         cause = new GitHubPushCause(pushBy);
                     }
                     if (asParameterizedJobMixIn(job).scheduleBuild(cause)) {
-                        LOGGER.info("SCM changes detected in " + job.getName() + ". Triggering " + name);
+                        LOGGER.info("SCM changes detected in " + job.getFullName() + ". Triggering #" + job.getNextBuildNumber());
                     } else {
-                        LOGGER.info("SCM changes detected in " + job.getName() + ". Job is already in the queue");
+                        LOGGER.info("SCM changes detected in " + job.getFullName() + ". Job is already in the queue");
                     }
                 }
             }

--- a/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
@@ -116,7 +116,8 @@ public class GitHubPushTrigger extends Trigger<Job<?, ?>> implements GitHubTrigg
                         cause = new GitHubPushCause(pushBy);
                     }
                     if (asParameterizedJobMixIn(job).scheduleBuild(cause)) {
-                        LOGGER.info("SCM changes detected in " + job.getFullName() + ". Triggering #" + job.getNextBuildNumber());
+                        LOGGER.info("SCM changes detected in " + job.getFullName()
+                                  + ". Triggering #" + job.getNextBuildNumber());
                     } else {
                         LOGGER.info("SCM changes detected in " + job.getFullName() + ". Job is already in the queue");
                     }


### PR DESCRIPTION
I saw a custom logger showing things like

```
… INFO com.cloudbees.jenkins.GitHubPushTrigger$1 run
SCM changes detected in master. Triggering  #123
```

Probably this was some project inside of a folder whose full name would have been useful to know, but it was not visible here.

Also note the gratuitous space.

@reviewbybees

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/120)
<!-- Reviewable:end -->
