### PR TITLE
[JENKINS-36445] Reduce length of displayed SHA1 in changes

### DIFF
--- a/src/main/java/com/coravy/hudson/plugins/github/GithubLinkAnnotator.java
+++ b/src/main/java/com/coravy/hudson/plugins/github/GithubLinkAnnotator.java
@@ -42,7 +42,9 @@ public class GithubLinkAnnotator extends ChangeLogAnnotator {
 
         if (change instanceof GitChangeSet) {
             GitChangeSet cs = (GitChangeSet) change;
-            text.wrapBy("", " (<a href='" + url.commitId(cs.getId()) + "'>commit: " + cs.getId() + "</a>)");
+            final String id = cs.getId();
+            text.wrapBy("", " (<a href='" + url.commitId(id)
+                        + "'>commit: " + id.substring(0, Math.min(id.length(), 7)) + "</a>)");
         }
     }
 

--- a/src/test/java/com/coravy/hudson/plugins/github/GithubLinkAnnotatorTest.java
+++ b/src/test/java/com/coravy/hudson/plugins/github/GithubLinkAnnotatorTest.java
@@ -2,12 +2,31 @@ package com.coravy.hudson.plugins.github;
 
 import static org.junit.Assert.assertEquals;
 import hudson.MarkupText;
+import hudson.plugins.git.GitChangeSet;
+import java.util.ArrayList;
+import org.junit.Before;
 
 import org.junit.Test;
 
 public class GithubLinkAnnotatorTest {
 
     private final static String GITHUB_URL = "http://github.com/juretta/iphone-project-tools/";
+    private final static String SHA1 = "deadbeef36cd854f4dd6fa40bf94c0c657681dd5";
+    private GitChangeSet changeSet;
+
+    @Before
+    public void createChangeSet() throws Exception {
+        ArrayList<String> lines = new ArrayList<String>();
+        lines.add("commit " + SHA1);
+        lines.add("tree 66236cf9a1ac0c589172b450ed01f019a5697c49");
+        lines.add("parent e74a24e995305bd67a180f0ebc57927e2b8783ce");
+        lines.add("author Author Name <author.name@nospam.com> 1363879004 +0100");
+        lines.add("committer Committer Name <committer.name@nospam.com> 1364199539 -0400");
+        lines.add("");
+        lines.add("    Committer and author are different in this commit.");
+        lines.add("");
+        changeSet = new GitChangeSet(lines, true);
+    }
 
     @Test
     public final void testAnnotateStringMarkupText() {
@@ -25,13 +44,44 @@ public class GithubLinkAnnotatorTest {
                         + "issues/9876/find'>close #9876</a> link");
     }
 
+    @Test
+    public final void testChangeSetAnnotateStringMarkupText() {
+        final String expectedChangeSetAnnotation
+                = " (<a href='" + GITHUB_URL + "commit/" + SHA1 + "'>commit: deadbee</a>)";
+        assertChangeSetAnnotatedTextEquals("An issue Closes #1 link",
+                "An issue <a href='" + GITHUB_URL
+                + "issues/1/find'>Closes #1</a> link"
+                + expectedChangeSetAnnotation);
+        assertChangeSetAnnotatedTextEquals("An issue Close #1 link",
+                "An issue <a href='" + GITHUB_URL
+                + "issues/1/find'>Close #1</a> link"
+                + expectedChangeSetAnnotation);
+        assertChangeSetAnnotatedTextEquals("An issue closes #123 link",
+                "An issue <a href='" + GITHUB_URL
+                + "issues/123/find'>closes #123</a> link"
+                + expectedChangeSetAnnotation);
+        assertChangeSetAnnotatedTextEquals("An issue close #9876 link",
+                "An issue <a href='" + GITHUB_URL
+                + "issues/9876/find'>close #9876</a> link"
+                + expectedChangeSetAnnotation);
+    }
+
     private void assertAnnotatedTextEquals(final String originalText,
             final String expectedAnnotatedText) {
+        assertEquals(expectedAnnotatedText, annotate(originalText, null));
+    }
+
+    private void assertChangeSetAnnotatedTextEquals(final String originalText,
+            final String expectedAnnotatedText) {
+        assertEquals(expectedAnnotatedText, annotate(originalText, changeSet));
+    }
+
+    private String annotate(final String originalText, GitChangeSet changeSet) {
         MarkupText markupText = new MarkupText(originalText);
 
         GithubLinkAnnotator annotator = new GithubLinkAnnotator();
-        annotator.annotate(new GithubUrl(GITHUB_URL), markupText, null);
+        annotator.annotate(new GithubUrl(GITHUB_URL), markupText, changeSet);
 
-        assertEquals(expectedAnnotatedText, markupText.toString());
+        return markupText.toString(true);
     }
 }


### PR DESCRIPTION
Most git repository browsing systems (bitbucket, cgit, github, gitweb)
present a short form of the SHA1 (commonly the first 7 characters) with
the clickable hyperlink that will take them to a page that includes the
full SHA1 of the commit.

This change reduces the visible text to the first 7 characters of the
SHA1, consistent with those other repository browsers.  It also adds
assertions that the expected format is used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/127)
<!-- Reviewable:end -->
