### PR TITLE
Show shortened SHA1 in user interface hyperlink

### DIFF
--- a/src/main/java/com/coravy/hudson/plugins/github/GithubLinkAnnotator.java
+++ b/src/main/java/com/coravy/hudson/plugins/github/GithubLinkAnnotator.java
@@ -8,6 +8,8 @@ import hudson.plugins.git.GitChangeSet;
 import hudson.scm.ChangeLogAnnotator;
 import hudson.scm.ChangeLogSet.Entry;
 
+import static java.lang.String.format;
+
 import java.util.regex.Pattern;
 
 /**
@@ -42,7 +44,10 @@ public class GithubLinkAnnotator extends ChangeLogAnnotator {
 
         if (change instanceof GitChangeSet) {
             GitChangeSet cs = (GitChangeSet) change;
-            text.wrapBy("", " (<a href='" + url.commitId(cs.getId()) + "'>commit: " + cs.getId() + "</a>)");
+            final String id = cs.getId();
+            text.wrapBy("", format(" (<a href='%s'>commit: %s</a>)",
+                                   url.commitId(id),
+                                   id.substring(0, Math.min(id.length(), 7))));
         }
     }
 

--- a/src/test/java/com/coravy/hudson/plugins/github/GithubLinkAnnotatorTest.java
+++ b/src/test/java/com/coravy/hudson/plugins/github/GithubLinkAnnotatorTest.java
@@ -1,37 +1,91 @@
 package com.coravy.hudson.plugins.github;
 
-import static org.junit.Assert.assertEquals;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import hudson.MarkupText;
-
+import hudson.plugins.git.GitChangeSet;
+import java.util.ArrayList;
+import java.util.Random;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
+@RunWith(DataProviderRunner.class)
 public class GithubLinkAnnotatorTest {
 
-    private final static String GITHUB_URL = "http://github.com/juretta/iphone-project-tools/";
+    private final static String GITHUB_URL = "http://github.com/juretta/iphone-project-tools";
+    private final static String SHA1 = "badbeef136cd854f4dd6fa40bf94c0c657681dd5";
+    private final static Random RANDOM = new Random();
+    private final String expectedChangeSetAnnotation = " ("
+            + "<a href='" + GITHUB_URL + "/commit/" + SHA1 + "'>"
+            + "commit: " + SHA1.substring(0, 7)
+            + "</a>)";
+    private static GitChangeSet changeSet;
 
-    @Test
-    public final void testAnnotateStringMarkupText() {
-        assertAnnotatedTextEquals("An issue Closes #1 link",
-                "An issue <a href='" + GITHUB_URL
-                        + "issues/1/find'>Closes #1</a> link");
-        assertAnnotatedTextEquals("An issue Close #1 link",
-                "An issue <a href='" + GITHUB_URL
-                        + "issues/1/find'>Close #1</a> link");
-        assertAnnotatedTextEquals("An issue closes #123 link",
-                "An issue <a href='" + GITHUB_URL
-                        + "issues/123/find'>closes #123</a> link");
-        assertAnnotatedTextEquals("An issue close #9876 link",
-                "An issue <a href='" + GITHUB_URL
-                        + "issues/9876/find'>close #9876</a> link");
+    @Before
+    public void createChangeSet() throws Exception {
+        ArrayList<String> lines = new ArrayList<String>();
+        lines.add("commit " + SHA1);
+        lines.add("tree 66236cf9a1ac0c589172b450ed01f019a5697c49");
+        lines.add("parent e74a24e995305bd67a180f0ebc57927e2b8783ce");
+        lines.add("author Author Name <author.name@nospam.com> 1363879004 +0100");
+        lines.add("committer Committer Name <committer.name@nospam.com> 1364199539 -0400");
+        lines.add("");
+        lines.add("    Committer and author are different in this commit.");
+        lines.add("");
+        changeSet = new GitChangeSet(lines, true);
     }
 
-    private void assertAnnotatedTextEquals(final String originalText,
-            final String expectedAnnotatedText) {
+    private static Object[] genActualAndExpected(String keyword) {
+        int issueNumber = RANDOM.nextInt(1000000);
+        final String innerText = keyword + " #" + issueNumber;
+        final String startHREF = "<a href='" + GITHUB_URL + "/issues/" + issueNumber + "/find'>";
+        final String endHREF = "</a>";
+        final String annotatedText = startHREF + innerText + endHREF;
+        return new Object[]{
+            // Input text to the annotate method
+            format("An issue %s link", innerText),
+            // Expected result from the annotate method
+            format("An issue %s link", annotatedText)
+        };
+    }
+
+    @DataProvider
+    public static Object[][] annotations() {
+        return new Object[][]{
+            genActualAndExpected("Closes"),
+            genActualAndExpected("Close"),
+            genActualAndExpected("closes"),
+            genActualAndExpected("close")
+        };
+    }
+
+    @Test
+    @UseDataProvider("annotations")
+    public void inputIsExpected(String input, String expected) throws Exception {
+        assertThat(format("For input '%s'", input),
+                annotate(input, null),
+                is(expected));
+    }
+
+    @Test
+    @UseDataProvider("annotations")
+    public void inputIsExpectedWithChangeSet(String input, String expected) throws Exception {
+        assertThat(format("For changeset input '%s'", input),
+                annotate(input, changeSet),
+                is(expected + expectedChangeSetAnnotation));
+    }
+
+    private String annotate(final String originalText, GitChangeSet changeSet) {
         MarkupText markupText = new MarkupText(originalText);
 
         GithubLinkAnnotator annotator = new GithubLinkAnnotator();
-        annotator.annotate(new GithubUrl(GITHUB_URL), markupText, null);
+        annotator.annotate(new GithubUrl(GITHUB_URL), markupText, changeSet);
 
-        assertEquals(expectedAnnotatedText, markupText.toString());
+        return markupText.toString(true);
     }
 }


### PR DESCRIPTION
Attempt to keep the code DRY.

Please consider this mostly a solicitation for feedback, rather than a final submission that is ready to merge into the master branch.

Is this what you were envisioning by using Hamcrest instead of the style used in the existing test?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/128)
<!-- Reviewable:end -->
