### PR TITLE
Print warning when repositories differ by case

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubRepositoryName.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubRepositoryName.java
@@ -196,7 +196,21 @@ public class GitHubRepositoryName {
 
     @Override
     public boolean equals(Object obj) {
-        return EqualsBuilder.reflectionEquals(this, obj);
+        boolean equalsByReflection = EqualsBuilder.reflectionEquals(this, obj);
+        if (obj instanceof GitHubRepositoryName) {
+            GitHubRepositoryName other = (GitHubRepositoryName) obj;
+            if (other.userName.equalsIgnoreCase(userName)
+                    && other.host.equalsIgnoreCase(host)
+                    && other.repositoryName.equalsIgnoreCase(repositoryName)
+                    && !equalsByReflection) {
+                LOGGER.warn("Repositories were equal ignoring case but considered unequal. "
+                        + "This usually indicates a configuration issue in which the case "
+                        + "of a repository name does not match the case on GitHub. "
+                        + "Webhooks will not work. Github repo: {}, Jenkins repo: {}", this, other);
+
+            }
+        }
+        return equalsByReflection;
     }
 
     @Override


### PR DESCRIPTION
There are many instances where people have run into hard to debug problems because Github webhooks in the plugin are case sensitive where the rest of Jenkins is case insensitive. Ideally, I'd like to change the equality behavior to be case insensitive, but I recognize that could be backwards incompatible for some people.

As a compromise, I'd like to add a WARN when comparing 2 repositories that would be equal but aren't because the case is different. At least in this case, when users look at the logs, it will be obvious what is happening.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/135)
<!-- Reviewable:end -->
