### PR TITLE
[FIXED JENKINS-35550] Upgrade to Credentials 2.1.0+ API for populating credentials drop-down

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
     </issueManagement>
 
     <properties>
-        <jenkins.version>1.580</jenkins.version>
-        <jenkins-test-harness.version>1.580</jenkins-test-harness.version>
+        <jenkins.version>1.609</jenkins.version>
+        <jenkins-test-harness.version>1.609</jenkins-test-harness.version>
         <release.skipTests>false</release.skipTests>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <findbugs-maven-plugin.version>3.0.2</findbugs-maven-plugin.version>
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>1.22</version>
+            <version>2.1.8</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/github/config/GitHubServerConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/github/config/GitHubServerConfig.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.github.config;
 
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.google.common.base.Function;
@@ -282,16 +283,18 @@ public class GitHubServerConfig extends AbstractDescribableImpl<GitHubServerConf
         }
 
         @SuppressWarnings("unused")
-        public ListBoxModel doFillCredentialsIdItems(@QueryParameter String apiUrl) {
+        public ListBoxModel doFillCredentialsIdItems(@QueryParameter String apiUrl,
+                                                     @QueryParameter String credentialsId) {
             if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
-                return new ListBoxModel();
+                return new StandardListBoxModel().includeCurrentValue(credentialsId);
             }
             return new StandardListBoxModel()
-                    .withEmptySelection()
-                    .withAll(lookupCredentials(
-                            StringCredentials.class,
+                    .includeEmptyValue()
+                    .includeMatchingAs(ACL.SYSTEM,
                             Jenkins.getInstance(),
-                            ACL.SYSTEM, fromUri(defaultIfBlank(apiUrl, GITHUB_URL)).build())
+                            StringCredentials.class,
+                            fromUri(defaultIfBlank(apiUrl, GITHUB_URL)).build(),
+                            CredentialsMatchers.always()
                     );
         }
 

--- a/src/main/java/org/jenkinsci/plugins/github/config/HookSecretConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/github/config/HookSecretConfig.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.github.config;
 
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import hudson.Extension;
@@ -14,8 +15,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
-
-import static com.cloudbees.plugins.credentials.CredentialsProvider.lookupCredentials;
+import org.kohsuke.stapler.QueryParameter;
 
 /**
  * Manages storing/retrieval of the shared secret for the hook.
@@ -56,18 +56,19 @@ public class HookSecretConfig extends AbstractDescribableImpl<HookSecretConfig> 
         }
 
         @SuppressWarnings("unused")
-        public ListBoxModel doFillCredentialsIdItems() {
+        public ListBoxModel doFillCredentialsIdItems(@QueryParameter String credentialsId) {
             if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
-                return new ListBoxModel();
+                return new StandardListBoxModel().includeCurrentValue(credentialsId);
             }
 
             return new StandardListBoxModel()
-                    .withEmptySelection()
-                    .withAll(lookupCredentials(
-                            StringCredentials.class,
-                            Jenkins.getInstance(),
+                    .includeEmptyValue()
+                    .includeMatchingAs(
                             ACL.SYSTEM,
-                            Collections.<DomainRequirement>emptyList())
+                            Jenkins.getInstance(),
+                            StringCredentials.class,
+                            Collections.<DomainRequirement>emptyList(),
+                            CredentialsMatchers.always()
                     );
         }
     }

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/config.groovy
@@ -11,7 +11,7 @@ f.entry(title: _("API URL"), field: "apiUrl") {
 }
 
 f.entry(title: _("Credentials"), field: "credentialsId") {
-    c.select()
+    c.select(context:app, includeUser:false, expressionAllowed:false)
 }
 
 f.block() {

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubTokenCredentialsCreator/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubTokenCredentialsCreator/config.groovy
@@ -12,7 +12,7 @@ f.entry(title: _("GitHub API URL"), field: "apiUrl",
 
 f.radioBlock(checked: true, name: "creds", value: "plugin", title: "From credentials") {
     f.entry(title: _("Credentials"), field: "credentialsId") {
-        c.select()
+        c.select(context: app, includeUser: true, expressionAllowed: false)
     }
 
     f.block() {

--- a/src/main/resources/org/jenkinsci/plugins/github/config/HookSecretConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/HookSecretConfig/config.groovy
@@ -4,5 +4,5 @@ def f = namespace(lib.FormTagLib);
 def c = namespace(lib.CredentialsTagLib);
 
 f.entry(title: _("Shared secret"), field: "credentialsId", help: descriptor.getHelpFile('sharedSecret')) {
-    c.select()
+    c.select(context: app, includeUser: false, expressionAllowed: false)
 }


### PR DESCRIPTION
See [JENKINS-35550](https://issues.jenkins-ci.org/browse/JENKINS-35550)

- In two of the cases the context is explicitly `Jenkins.getInstance()` and no user credentials should be considered.
- In one case - conversion - then user credentials stores should be included

@reviewbybees @jenkinsci/code-reviewers

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/154)
<!-- Reviewable:end -->
