### PR TITLE
[JENKINS-39590] Switch to `GitHub.parseEventPayload` for event parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.69</version>
+            <version>1.80</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/github/webhook/subscriber/PingGHEventSubscriber.java
+++ b/src/main/java/org/jenkinsci/plugins/github/webhook/subscriber/PingGHEventSubscriber.java
@@ -61,23 +61,24 @@ public class PingGHEventSubscriber extends GHEventsSubscriber {
      */
     @Override
     protected void onEvent(GHEvent event, String payload) {
+        GHEventPayload.Ping ping;
         try {
-            GHEventPayload.Ping ping =
-                    GitHub.offline().parseEventPayload(new StringReader(payload), GHEventPayload.Ping.class);
-            GHRepository repository = ping.getRepository();
-            if (repository != null) {
-                LOGGER.info("{} webhook received from repo <{}>!", event, repository.getHtmlUrl());
-                monitor.resolveProblem(GitHubRepositoryName.create(repository.getHtmlUrl().toExternalForm()));
-            } else {
-                GHOrganization organization = ping.getOrganization();
-                if (organization != null) {
-                    LOGGER.info("{} webhook received from org <{}>!", event, organization.getUrl());
-                } else {
-                    LOGGER.warn("{} webhook received with unexpected payload", event);
-                }
-            }
+            ping = GitHub.offline().parseEventPayload(new StringReader(payload), GHEventPayload.Ping.class);
         } catch (IOException e) {
             LOGGER.warn("Received malformed PingEvent: " + payload, e);
+            return;
+        }
+        GHRepository repository = ping.getRepository();
+        if (repository != null) {
+            LOGGER.info("{} webhook received from repo <{}>!", event, repository.getHtmlUrl());
+            monitor.resolveProblem(GitHubRepositoryName.create(repository.getHtmlUrl().toExternalForm()));
+        } else {
+            GHOrganization organization = ping.getOrganization();
+            if (organization != null) {
+                LOGGER.info("{} webhook received from org <{}>!", event, organization.getUrl());
+            } else {
+                LOGGER.warn("{} webhook received with unexpected payload", event);
+            }
         }
     }
 }


### PR DESCRIPTION
See [JENKINS-39590](https://issues.jenkins-ci.org/browse/JENKINS-39590)

Work In Progress until https://github.com/kohsuke/github-api/pull/306 is merged and https://github.com/jenkinsci/github-api-plugin/ gets a release (also needs to be on top of https://github.com/jenkinsci/github-plugin/pull/153)

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/155)
<!-- Reviewable:end -->
