### PR TITLE
add field for setting context for pending step

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubSetCommitStatusBuilder.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubSetCommitStatusBuilder.java
@@ -11,6 +11,7 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import jenkins.tasks.SimpleBuildStep;
 import org.jenkinsci.plugins.github.common.ExpandableMessage;
+import org.jenkinsci.plugins.github.extension.status.GitHubStatusContextSource;
 import org.jenkinsci.plugins.github.extension.status.StatusErrorHandler;
 import org.jenkinsci.plugins.github.extension.status.misc.ConditionalResult;
 import org.jenkinsci.plugins.github.status.GitHubCommitStatusSetter;
@@ -35,6 +36,7 @@ public class GitHubSetCommitStatusBuilder extends Builder implements SimpleBuild
     private static final ExpandableMessage DEFAULT_MESSAGE = new ExpandableMessage("");
 
     private ExpandableMessage statusMessage = DEFAULT_MESSAGE;
+    private GitHubStatusContextSource contextSource = new DefaultCommitContextSource();
 
     @DataBoundConstructor
     public GitHubSetCommitStatusBuilder() {
@@ -48,11 +50,23 @@ public class GitHubSetCommitStatusBuilder extends Builder implements SimpleBuild
     }
 
     /**
+     * @return Context provider
+     */
+    public GitHubStatusContextSource getContextSource() {
+        return contextSource;
+    }
+
+    /**
      * @since 1.14.1
      */
     @DataBoundSetter
     public void setStatusMessage(ExpandableMessage statusMessage) {
         this.statusMessage = statusMessage;
+    }
+
+    @DataBoundSetter
+    public void setContextSource(GitHubStatusContextSource contextSource) {
+        this.contextSource = contextSource;
     }
 
     @Override
@@ -64,7 +78,7 @@ public class GitHubSetCommitStatusBuilder extends Builder implements SimpleBuild
         GitHubCommitStatusSetter setter = new GitHubCommitStatusSetter();
         setter.setReposSource(new AnyDefinedRepositorySource());
         setter.setCommitShaSource(new BuildDataRevisionShaSource());
-        setter.setContextSource(new DefaultCommitContextSource());
+        setter.setContextSource(contextSource);
         setter.setErrorHandlers(Collections.<StatusErrorHandler>singletonList(new ShallowAnyErrorHandler()));
 
         setter.setStatusResultSource(new ConditionalStatusResultSource(

--- a/src/main/java/com/cloudbees/jenkins/GitHubSetCommitStatusBuilder.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubSetCommitStatusBuilder.java
@@ -51,6 +51,7 @@ public class GitHubSetCommitStatusBuilder extends Builder implements SimpleBuild
 
     /**
      * @return Context provider
+     * @since FIXME
      */
     public GitHubStatusContextSource getContextSource() {
         return contextSource;
@@ -64,6 +65,9 @@ public class GitHubSetCommitStatusBuilder extends Builder implements SimpleBuild
         this.statusMessage = statusMessage;
     }
 
+    /**
+     * @since FIXME
+     */
     @DataBoundSetter
     public void setContextSource(GitHubStatusContextSource contextSource) {
         this.contextSource = contextSource;

--- a/src/main/java/com/cloudbees/jenkins/GitHubSetCommitStatusBuilder.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubSetCommitStatusBuilder.java
@@ -93,6 +93,14 @@ public class GitHubSetCommitStatusBuilder extends Builder implements SimpleBuild
         setter.perform(build, workspace, launcher, listener);
     }
 
+
+    public Object readResolve() {
+        if (getContextSource() == null) {
+            setContextSource(new DefaultCommitContextSource());
+        }
+        return this;
+    }
+
     @Extension
     public static class Descriptor extends BuildStepDescriptor<Builder> {
         @Override

--- a/src/main/resources/com/cloudbees/jenkins/GitHubSetCommitStatusBuilder/config.groovy
+++ b/src/main/resources/com/cloudbees/jenkins/GitHubSetCommitStatusBuilder/config.groovy
@@ -9,6 +9,8 @@ if (instance == null) {
     instance = new GitHubSetCommitStatusBuilder()
 }
 
+f.dropdownDescriptorSelector(title: _('Commit context: '), field: 'contextSource')
+
 f.advanced() {
     f.entry(title: _('Build status message'), field: 'statusMessage') {
         f.property()


### PR DESCRIPTION
I've updated the pending step with the context field also available in the after build step.

But I couldn't get the failing test updated to make it work again, so if anyone can give me some pointers there? 

I'm totally new to java, and somethings are easy to derive from existing code, but I actually have no idea what I'm doing 💩. But the implementation is functional in my installation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/159)
<!-- Reviewable:end -->
