### PR TITLE
Add support for "githubPush" declarative pipeline trigger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jenkins-ci</groupId>
+            <artifactId>symbol-annotation</artifactId>
+            <version>1.5</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
             <version>1.11</version>

--- a/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
@@ -28,6 +28,7 @@ import org.jenkinsci.plugins.github.admin.GitHubHookRegisterProblemMonitor;
 import org.jenkinsci.plugins.github.config.GitHubPluginConfig;
 import org.jenkinsci.plugins.github.internal.GHPluginConfigException;
 import org.jenkinsci.plugins.github.migration.Migrator;
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.AncestorInPath;
@@ -248,6 +249,7 @@ public class GitHubPushTrigger extends Trigger<Job<?, ?>> implements GitHubTrigg
     }
 
     @Extension
+    @Symbol("githubPush")
     public static class DescriptorImpl extends TriggerDescriptor {
         private final transient SequentialExecutionQueue queue =
                 new SequentialExecutionQueue(Executors.newSingleThreadExecutor(threadFactory()));


### PR DESCRIPTION
There is currently no way to add this trigger to a declarative syntax pipeline. This adds support to define a Jenkinsfile as:
```
pipeline {
    agent any
    triggers {
        githubPush()
    }

    stages {
         // ...
    }
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/166)
<!-- Reviewable:end -->
