### PR TITLE
Use display url api to generate run backlink

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,12 @@
             <version>1.11</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>display-url-api</artifactId>
+            <version>1.0</version>
+        </dependency>
+
         <dependency><!-- exists in the core -->
             <groupId>org.jenkins-ci.modules</groupId>
             <artifactId>instance-identity</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>display-url-api</artifactId>
-            <version>1.0</version>
+            <version>2.0</version>
         </dependency>
 
         <dependency><!-- exists in the core -->

--- a/src/main/java/org/jenkinsci/plugins/github/status/sources/BuildRefBackrefSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github/status/sources/BuildRefBackrefSource.java
@@ -4,6 +4,7 @@ import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.jenkinsci.plugins.github.extension.status.GitHubStatusBackrefSource;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -25,7 +26,7 @@ public class BuildRefBackrefSource extends GitHubStatusBackrefSource {
     @SuppressWarnings("deprecation")
     @Override
     public String get(Run<?, ?> run, TaskListener listener) {
-        return run.getAbsoluteUrl();
+        return DisplayURLProvider.get().getRunURL(run);
     }
 
     @Extension

--- a/src/test/java/org/jenkinsci/plugins/github/status/sources/BuildRefBackrefSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/status/sources/BuildRefBackrefSourceTest.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.github.status.sources;
 import hudson.model.FreeStyleProject;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,15 +32,13 @@ public class BuildRefBackrefSourceTest {
 
     @Test
     /**
-     * Should've used mocked Run, but getAbsoluteUrl is final.
-     *
      * @throws Exception
      */
     public void shouldReturnRunAbsoluteUrl() throws Exception {
         Run<?, ?> run = jenkinsRule.buildAndAssertSuccess(jenkinsRule.createFreeStyleProject());
 
         String result = new BuildRefBackrefSource().get(run, listener);
-        assertThat("state", result, is(run.getAbsoluteUrl()));
+        assertThat("state", result, is(DisplayURLProvider.get().getRunURL(run)));
     }
 
 }


### PR DESCRIPTION
When Blue Ocean is installed we can generate the backlink to its web UI instead of Jenkins classic. Same code has been adopted by mailer, github branch source and other plugins that generate links to the UI.

@reviewbybees 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/167)
<!-- Reviewable:end -->
