### PR TITLE
Add push event information as arguments to triggered jobs.

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
@@ -8,9 +8,16 @@ import hudson.XmlFile;
 import hudson.console.AnnotatedLargeText;
 import hudson.model.AbstractProject;
 import hudson.model.Action;
+import hudson.model.CauseAction;
 import hudson.model.Item;
 import hudson.model.Job;
+import hudson.model.ParameterDefinition;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Project;
+import hudson.model.StringParameterValue;
+import hudson.model.queue.QueueTaskFuture;
 import hudson.triggers.SCMTrigger;
 import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
@@ -44,9 +51,11 @@ import java.io.PrintStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.text.DateFormat;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -79,10 +88,12 @@ public class GitHubPushTrigger extends Trigger<Job<?, ?>> implements GitHubTrigg
     /**
      * Called when a POST is made.
      */
-    public void onPost(String triggeredByUser) {
+    public void onPost(String triggeredByUser, String ref, String head) {
         onPost(GitHubTriggerEvent.create()
                 .withOrigin(SCMEvent.originOf(Stapler.getCurrentRequest()))
                 .withTriggeredByUser(triggeredByUser)
+                .withRef(ref)
+                .withHead(head)
                 .build()
         );
     }
@@ -92,6 +103,8 @@ public class GitHubPushTrigger extends Trigger<Job<?, ?>> implements GitHubTrigg
      */
     public void onPost(final GitHubTriggerEvent event) {
         final String pushBy = event.getTriggeredByUser();
+        final String ref = event.getRef();
+        final String head = event.getHead();
         DescriptorImpl d = getDescriptor();
         d.checkThreadPoolSizeAndUpdateIfNecessary();
         d.queue.execute(new Runnable() {
@@ -140,7 +153,23 @@ public class GitHubPushTrigger extends Trigger<Job<?, ?>> implements GitHubTrigg
                         LOGGER.warn("Failed to parse the polling log", e);
                         cause = new GitHubPushCause(pushBy);
                     }
-                    if (asParameterizedJobMixIn(job).scheduleBuild(cause)) {
+
+                    // Get the parameters defined by the job, as we will be overriding certain values
+                    List<ParameterValue> values = getDefaultParameters();
+                    Iterator<ParameterValue> it = values.iterator();
+                    while (it.hasNext()) {
+                        ParameterValue pv = it.next();
+                        if (parameterIsOverridable(pv.getName())) {
+                            it.remove();
+                        }
+                    }
+                    values.add(new StringParameterValue("ref", ref));
+                    values.add(new StringParameterValue("head", head));
+
+                    // Schedule the job with the parameters and cause
+                    QueueTaskFuture<?> build = asParameterizedJobMixIn(job)
+                            .scheduleBuild2(0, new ParametersAction(values), new CauseAction(cause));
+                    if (build != null) {
                         LOGGER.info("SCM changes detected in " + job.getFullName()
                                 + ". Triggering #" + job.getNextBuildNumber());
                     } else {
@@ -149,6 +178,30 @@ public class GitHubPushTrigger extends Trigger<Job<?, ?>> implements GitHubTrigg
                 }
             }
         });
+    }
+
+    /**
+     * Returns the default parameter values for the parameters of this job
+     */
+    private List<ParameterValue> getDefaultParameters() {
+        ArrayList<ParameterValue> values = new ArrayList<ParameterValue>();
+        ParametersDefinitionProperty pdp = this.job.getProperty(ParametersDefinitionProperty.class);
+        if (pdp != null) {
+            for (ParameterDefinition pd : pdp.getParameterDefinitions()) {
+                if (pd.getName().equals("sha1")) {
+                    continue;
+                }
+                values.add(pd.getDefaultParameterValue());
+            }
+        }
+        return values;
+    }
+
+    /**
+     * Returns whether or not a given parameter WILL be overridden
+     */
+    private static boolean parameterIsOverridable(String paramName) {
+        return "ref".equalsIgnoreCase(paramName) || "head".equalsIgnoreCase(paramName);
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/GitHubTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubTrigger.java
@@ -23,7 +23,7 @@ public interface GitHubTrigger {
     void onPost();
 
     // TODO: document me
-    void onPost(String triggeredByUser);
+    void onPost(String triggeredByUser, String ref, String head);
 
     /**
      * Obtains the list of the repositories that this trigger is looking at.

--- a/src/main/java/com/cloudbees/jenkins/GitHubTriggerEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubTriggerEvent.java
@@ -22,11 +22,21 @@ public class GitHubTriggerEvent {
      * The user that the event was provided by.
      */
     private final String triggeredByUser;
+    /**
+     * The user reference that the event affected
+     */
+    private final String ref;
+    /**
+     * The head of the repo after the event
+     */
+    private final String head;
 
-    private GitHubTriggerEvent(long timestamp, String origin, String triggeredByUser) {
+    private GitHubTriggerEvent(long timestamp, String origin, String triggeredByUser, String ref, String head) {
         this.timestamp = timestamp;
         this.origin = origin;
         this.triggeredByUser = triggeredByUser;
+        this.ref = ref;
+        this.head = head;
     }
 
     public static Builder create() {
@@ -43,6 +53,14 @@ public class GitHubTriggerEvent {
 
     public String getTriggeredByUser() {
         return triggeredByUser;
+    }
+
+    public String getRef() {
+        return ref;
+    }
+
+    public String getHead() {
+        return head;
     }
 
     @Override
@@ -62,7 +80,16 @@ public class GitHubTriggerEvent {
         if (origin != null ? !origin.equals(that.origin) : that.origin != null) {
             return false;
         }
-        return triggeredByUser != null ? triggeredByUser.equals(that.triggeredByUser) : that.triggeredByUser == null;
+        if (triggeredByUser != null ? !triggeredByUser.equals(that.triggeredByUser) : that.triggeredByUser != null) {
+            return false;
+        }
+        if (ref != null ? !ref.equals(that.ref) : that.ref != null) {
+            return false;
+        }
+        if (head != null ? !head.equals(that.head) : that.head != null) {
+            return false;
+        }
+        return true;
     }
 
     @Override
@@ -70,6 +97,8 @@ public class GitHubTriggerEvent {
         int result = (int) (timestamp ^ (timestamp >>> 32));
         result = 31 * result + (origin != null ? origin.hashCode() : 0);
         result = 31 * result + (triggeredByUser != null ? triggeredByUser.hashCode() : 0);
+        result = 31 * result + (ref != null ? ref.hashCode() : 0);
+        result = 31 * result + (head != null ? head.hashCode() : 0);
         return result;
     }
 
@@ -79,6 +108,8 @@ public class GitHubTriggerEvent {
                 + "timestamp=" + timestamp
                 + ", origin='" + origin + '\''
                 + ", triggeredByUser='" + triggeredByUser + '\''
+               + ", ref='" + ref + '\''
+               + ", head='" + head + '\''
                 + '}';
     }
 
@@ -89,6 +120,8 @@ public class GitHubTriggerEvent {
         private long timestamp;
         private String origin;
         private String triggeredByUser;
+        private String ref;
+        private String head;
 
         private Builder() {
             timestamp = System.currentTimeMillis();
@@ -109,8 +142,18 @@ public class GitHubTriggerEvent {
             return this;
         }
 
+        public Builder withRef(String ref) {
+            this.ref = ref;
+            return this;
+        }
+
+        public Builder withHead(String head) {
+            this.head = head;
+            return this;
+        }
+
         public GitHubTriggerEvent build() {
-            return new GitHubTriggerEvent(timestamp, origin, triggeredByUser);
+            return new GitHubTriggerEvent(timestamp, origin, triggeredByUser, ref, head);
         }
 
         @Override
@@ -119,6 +162,8 @@ public class GitHubTriggerEvent {
                     + "timestamp=" + timestamp
                     + ", origin='" + origin + '\''
                     + ", triggeredByUser='" + triggeredByUser + '\''
+                   + ", ref='" + ref + '\''
+                   + ", head='" + head + '\''
                     + '}';
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventSubscriber.java
+++ b/src/main/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventSubscriber.java
@@ -75,6 +75,8 @@ public class DefaultPushGHEventSubscriber extends GHEventsSubscriber {
         }
         URL repoUrl = push.getRepository().getUrl();
         final String pusherName = push.getPusher().getName();
+        final String ref = push.getRef();
+        final String head = push.getHead();
         LOGGER.info("Received PushEvent for {} from {}", repoUrl, event.getOrigin());
         final GitHubRepositoryName changedRepository = GitHubRepositoryName.create(repoUrl.toExternalForm());
 
@@ -97,6 +99,8 @@ public class DefaultPushGHEventSubscriber extends GHEventsSubscriber {
                                         .withTimestamp(event.getTimestamp())
                                         .withOrigin(event.getOrigin())
                                         .withTriggeredByUser(pusherName)
+                                        .withHead(head)
+                                        .withRef(ref)
                                         .build()
                                 );
                             } else {

--- a/src/test/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventListenerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventListenerTest.java
@@ -29,6 +29,8 @@ public class DefaultPushGHEventListenerTest {
 
     public static final GitSCM GIT_SCM_FROM_RESOURCE = new GitSCM("ssh://git@github.com/lanwen/test.git");
     public static final String TRIGGERED_BY_USER_FROM_RESOURCE = "lanwen";
+    public static final String MASTER_BRANCH_REF = "refs/heads/master";
+    public static final String HEAD_COMMIT = "1eee2db8927ab3f7ec983b2e6052f351dd61a419";
 
     @Rule
     public JenkinsRule jenkins = new JenkinsRule();
@@ -62,6 +64,8 @@ public class DefaultPushGHEventListenerTest {
                 .withTimestamp(subscriberEvent.getTimestamp())
                 .withOrigin("shouldParsePushPayload")
                 .withTriggeredByUser(TRIGGERED_BY_USER_FROM_RESOURCE)
+                .withRef(MASTER_BRANCH_REF)
+                .withHead(HEAD_COMMIT)
                 .build()
         ));
     }
@@ -85,6 +89,8 @@ public class DefaultPushGHEventListenerTest {
                 .withTimestamp(subscriberEvent.getTimestamp())
                 .withOrigin("shouldReceivePushHookOnWorkflow")
                 .withTriggeredByUser(TRIGGERED_BY_USER_FROM_RESOURCE)
+                .withRef(MASTER_BRANCH_REF)
+                .withHead(HEAD_COMMIT)
                 .build()
         ));
     }


### PR DESCRIPTION
This change adds the git reference and head commit as arguments to triggered jobs.  This allows Jenkins jobs to implement specialized logic.  For example, a job can now have different behavior if the develop branch is pushed to vs. master.  