### PR TITLE
[JENKINS-43786] Adapted the administrative monitor to the new UI definition

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/github/admin/GitHubHookRegisterProblemMonitor/message.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/admin/GitHubHookRegisterProblemMonitor/message.groovy
@@ -2,10 +2,10 @@ package org.jenkinsci.plugins.github.admin.GitHubHookRegisterProblemMonitor
 
 def f = namespace(lib.FormTagLib)
 
-div(class: 'warning') {
+div(class: 'alert alert-warning') {
     form(method: 'post', action: "${rootURL}/${my?.url}/act", name: my?.id) {
-        text(_('hook.registering.problem'))
         f.submit(name: 'yes', value: _('view'))
         f.submit(name: 'no', value: _('dismiss'))
     }
+    text(_('hook.registering.problem'))
 }


### PR DESCRIPTION
[JENKINS-43786](https://issues.jenkins-ci.org/browse/JENKINS-43786)

Downstream of https://github.com/jenkinsci/jenkins/pull/2857

### Screenshot

![screenshot-2017-9-14 manage jenkins jenkins 1](https://user-images.githubusercontent.com/1021745/30452771-1662d5d8-9997-11e7-88ec-7899ba048759.png)


@jenkinsci/code-reviewers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/177)
<!-- Reviewable:end -->
