### PR TITLE
Cleanup help text blocks

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/config.groovy
@@ -24,7 +24,7 @@ f.section(title: descriptor.displayName) {
         if (GitHubPushTrigger.ALLOW_HOOKURL_OVERRIDE) {
             f.entry(title: _("Override Hook URL")) {
                 table(width: "100%", style: "margin-left: 7px;") {
-                    f.optionalBlock(title: _("Specify another hook url for GitHub configuration"),
+                    f.optionalBlock(title: _("Specify another hook URL for GitHub configuration"),
                             inline: true,
                             field: "overrideHookUrl",
                             checked: instance.overrideHookURL) {
@@ -48,4 +48,3 @@ f.section(title: descriptor.displayName) {
         }
     }
 }
-

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/help-additional.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/help-additional.html
@@ -1,4 +1,4 @@
 <div>
-    Additional actions can help you with some routine. For example you can convert your existing login + password 
-    (stored in credentials or directly) to GitHub personal token.
+    Additional actions can help you with some routines. For example, you can convert your existing login + password 
+    (stored in credentials or directly) to a GitHub personal token.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/help-overrideHookUrl.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/help-overrideHookUrl.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
   <l:ajax>
     <div>
-      If your Jenkins runs inside the firewall and not directly reachable from the internet,
+      If your Jenkins runs inside a firewall and is not directly reachable from the internet,
       set up a reverse proxy, port tunneling, and so on so that GitHub can deliver a POST request
       to your Jenkins at <tt><a href="${rootURL}/github-webhook/">${app.rootUrl}github-webhook/</a></tt>.
       Then specify the URL that GitHub should POST to here.

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/help.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/help.jelly
@@ -5,38 +5,32 @@
             <h3>By default</h3>
 
             <p>
-                This plugin don't do anything with GitHub api unless you add config with credentials.
-                So if you don't want to add any config, you can setup hooks for this jenkins instance manually.
+                This plugin doesn't do anything with the GitHub API unless you add a configuration with credentials.
+                So if you don't want to add any configuration, you can setup hooks for this Jenkins instance manually.
                 <br/>
-                In this mode, in addition to configure projects with "<i>Build when a change is pushed to GitHub</i>",
+                In this mode, in addition to configuring projects with "<i>Build when a change is pushed to GitHub</i>",
                 you need to ensure that Jenkins gets a POST to its
-                <tt>
-                    <a href="${rootURL}/github-webhook/">${app.rootUrl}github-webhook/</a>
-                </tt>
+                <tt><a href="${rootURL}/github-webhook/">${app.rootUrl}github-webhook/</a></tt>.
             </p>
 
             <h3>If you setup credentials</h3>
             <p>
-                In this mode, Jenkins will add/remove hook URLs to GitHub based on the project configuration of
-                Jenkins.
+                In this mode, Jenkins will add/remove hook URLs to GitHub based on the project configuration.
                 Jenkins has a single post-commit hook URL for all the repositories, and this URL will be added
-                to
-                all the GitHub repositories Jenkins is interested in. You should provide credentials with scope
-                <b>admin:repo_hook</b>
-                for every repo which should be managed by Jenkins. It needs to read current list of hooks,
-                create new hooks and remove old.
+                to all the GitHub repositories Jenkins is interested in. You should provide credentials with scope
+                <b>admin:repo_hook</b> for every repository which should be managed by Jenkins. It needs to read the
+                current list of hooks, create new hooks and remove old hooks.
 
                 <p>
-                    Hook URL is
+                    The Hook URL is
                     <tt>
                         <a href="${rootURL}/github-webhook/">${app.rootUrl}github-webhook/</a>
                     </tt>
                     ,
                     and it needs to be accessible from the internet. If you have a firewall and such between
-                    GitHub
-                    and Jenkins, you can set up a reverse proxy and override the hook URL that Jenkins registers
-                    to GitHub,
-                    by checking "override hook URL" in advanced configuration and specify the URL GitHub should POST to.
+                    GitHub and Jenkins, you can set up a reverse proxy and override the hook URL that Jenkins registers
+                    to GitHub, by checking "override hook URL" in the advanced configuration and specify to which URL
+                    GitHub should POST.
                 </p>
             </p>
         </div>

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/help-apiUrl.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/help-apiUrl.html
@@ -1,7 +1,7 @@
 <div>
     API endpoint of a GitHub server.
 
-    To use public github.com, leave this field
+    To use public <code>github.com</code>, leave this field
     to the default value of <code>https://api.github.com</code>.
 
     Otherwise if you use GitHub Enterprise, specify its API endpoint here

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/help-credentialsId.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/help-credentialsId.html
@@ -13,11 +13,11 @@
     <a href="https://wiki.jenkins-ci.org/display/JENKINS/Plain+Credentials+Plugin">Plain Credentials Plugin</a><br/>
 
     <p>
-        <b>WARN!</b> Creds are filtered on changing custom GitHub url<br/>
+        <b>WARNING!</b> Credentials are filtered on changing custom GitHub URL<br/>
     </p>
 
     <p>
-        If you have an existing GitHub login and password you can convert it to a token automatically with help of «<b>Manage
+        If you have an existing GitHub login and password you can convert it to a token automatically with the help of «<b>Manage
         additional GitHub actions</b>»
     </p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/help-manageHooks.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/help-manageHooks.html
@@ -1,4 +1,4 @@
 <div>
-    Is this config will be used to manage creds for repos where it has admin rights?
-    If unchecked, this credentials still can be used to manipulate commit statuses, but will be ignored to manage hooks
+    Will this configuration will be used to manage credentials for repositories where it has admin rights?
+    If unchecked, this credentials still can be used to manipulate commit statuses, but will be ignored to manage hooks.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/help-name.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/help-name.html
@@ -1,6 +1,6 @@
 <div>
-    An optional name to help disambiguation of API URLs. If you have multiple GitHub Enterprise servers with non-helpful
+    An optional name to help with the disambiguation of API URLs. If you have multiple GitHub Enterprise servers with non-helpful
     names such as <code>s21356.example.com</code> and <code>s21368.example.com</code> then giving these names can
-    help users when they need to select the correct server from a drop-down list. If you do not provide a name
+    help users when they need to select the correct server from a drop-down list. If you do not provide a name,
     then a "best guess" will be made from the hostname part of the API URL.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/help.html
@@ -1,5 +1,5 @@
 <div>
-    Pair of GitHub token and server url. If no any custom url specified, then default <code>api.github.com</code> will be used.
+    Pair of GitHub token and server URL. If no any custom URL is specified, then the default <code>api.github.com</code> will be used.
     If your Jenkins uses multiple repositories that are spread across different
-    user accounts, you can list them all here as separate configs.
+    user accounts, you can list them all here as separate configurations.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubTokenCredentialsCreator/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubTokenCredentialsCreator/help.html
@@ -1,8 +1,8 @@
 <div>
-    Helper to convert existing username-password credentials or directly login+password to
+    Helper to convert existing username-password credentials or directly login+password to a
     <a href="https://github.com/settings/tokens">GitHub personal token</a>.<br/>
 
-    This helper don't stores any entered data, but only registers token with all scopes needed to plugin.<br/>
-    After token registration it will be stored as «Secret text» credentials with domain requirements corresponding to
-    given api url. It will be available after refreshing the global config page
+    This helper doesn't store any entered data, but only registers a new token with all scopes needed to plugin.<br/>
+    After token registration, it will be stored as «Secret text» credentials with domain requirements corresponding to
+    given API URL. It will be available after refreshing the Global Confiration page.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/github/config/HookSecretConfig/help-sharedSecret.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/HookSecretConfig/help-sharedSecret.html
@@ -1,5 +1,5 @@
 <div>
     A shared secret token GitHub will use to sign requests in order for Jenkins to verify that the request came from GitHub.
     If left blank, this feature will not be used.
-    Please use <b>different</b> from token secret.
+    Please use a <b>different</b> token from the token secret.
 </div>


### PR DESCRIPTION
There are a few gramatical errors in the help text associated with the plugin. I am not an English major, so there may still be issues. I do think this improves it a bit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/178)
<!-- Reviewable:end -->
