### PR TITLE
Update github-api dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.86</version>
+            <version>1.90</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This is done to accommodate the larger IDs for PRs.

I'm not sure this is actually needed - since this(https://github.com/kohsuke/github-api/issues/387) thing is happening. But just in case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/180)
<!-- Reviewable:end -->
