### PR TITLE
[JENKINS-48139] Support ignoring push events from certain github users (ie a Jenkins user)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github/config/GitHubPluginConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/github/config/GitHubPluginConfig.java
@@ -63,6 +63,13 @@ public class GitHubPluginConfig extends GlobalConfiguration {
     private URL hookUrl;
     private HookSecretConfig hookSecretConfig = new HookSecretConfig(null);
 
+    /**
+     * @see #getCommittersToIgnore()
+     * @see #setCommittersToIgnore(String)
+     */
+    private String committersToIgnore = "";
+
+
     private transient boolean overrideHookUrl;
 
     /**
@@ -136,6 +143,45 @@ public class GitHubPluginConfig extends GlobalConfiguration {
 
     public List<Descriptor> actions() {
         return Collections.singletonList(Jenkins.getInstance().getDescriptor(GitHubTokenCredentialsCreator.class));
+    }
+
+    /**
+     * Comma-delimited list of git usernames to ignore when receiving push events (ie, jenkinsuser)
+     *
+     * Defaults to empty string
+     *
+     * @since 1.28.2
+     */
+    public String getCommittersToIgnore() {
+        return committersToIgnore;
+    }
+
+    /**
+     * Array of git usernames to ignore when receiving push events (ie, jenkinsuser)
+     *
+     * Defaults to empty array
+     *
+     * @since 1.28.2
+     */
+    public String[] getCommittersToIgnoreArray() {
+        String[] committers = new String[0];
+        if (null != committersToIgnore && !committersToIgnore.isEmpty()) {
+            try {
+                committers = committersToIgnore.split(",");
+            } catch (Exception e) {
+                LOGGER.error("Caught exception trying to parse "
+                    + "the list of committers to ignore. Malformed list?", e);
+            }
+        }
+        return committers;
+    }
+
+    /**
+     * @param committersToIgnore comma-delimited list of git usernames to
+     * ignore when receiving push events (ie, jenkinsuser)
+     */
+    public void setCommittersToIgnore(String committersToIgnore) {
+        this.committersToIgnore = committersToIgnore;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventSubscriber.java
+++ b/src/main/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventSubscriber.java
@@ -101,7 +101,7 @@ public class DefaultPushGHEventSubscriber extends GHEventsSubscriber {
 
                                 boolean toIgnore = false;
                                 for (String committer : config.getCommittersToIgnoreArray()) {
-                                    if (committer.equals(pusherName)) {
+                                    if (committer.trim().equals(pusherName)) {
                                         toIgnore = true;
                                         break;
                                     }

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/config.groovy
@@ -46,5 +46,10 @@ f.section(title: descriptor.displayName) {
                     name: "actions",
                     oneEach: "true", hasHeader: "true", descriptors: instance.actions())
         }
+
+        f.entry(title: _("Ignore push events from certain git users"),
+                help: descriptor.getHelpFile('committersToIgnore'), field: "committersToIgnore") {
+            f.textbox()
+        }
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/help-committersToIgnore.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/help-committersToIgnore.jelly
@@ -2,16 +2,18 @@
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
     <l:ajax>
         <div>
-            A comma-delimited list of usernames to ignore push events from. These events will be handled
-            and logged by the plugin but will not trigger builds. The obvious use-case for this is
-            ignoring push events by a designated Jenkins git user, so that your builds don't trigger
-            more builds.
+            <p>
+                A comma-delimited list of usernames to ignore push events from. These events will be handled
+                and logged by the plugin but will not trigger builds. The obvious use-case for this is
+                ignoring push events by a designated Jenkins git user, so that your builds don't trigger
+                more builds.
+    
+                This must <b>exactly</b> match their Github username.
 
-            This must <b>exactly</b> match their Github username.
-
-            Examples:
-            <i>jenkinsuser</i>
-            <i>jenkinsuser,otheruser,anotheruser,yetanotheruser</i>
+                Examples:
+                <i>jenkinsuser</i>
+                <i>jenkinsuser,otheruser,anotheruser,yetanotheruser</i>
+            </p>
         </div>
     </l:ajax>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/help-committersToIgnore.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/help-committersToIgnore.jelly
@@ -1,0 +1,17 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+    <l:ajax>
+        <div>
+            A comma-delimited list of usernames to ignore push events from. These events will be handled
+            and logged by the plugin but will not trigger builds. The obvious use-case for this is
+            ignoring push events by a designated Jenkins git user, so that your builds don't trigger
+            more builds.
+
+            This must <b>exactly</b> match their Github username.
+
+            Examples:
+            <i>jenkinsuser</i>
+            <i>jenkinsuser,otheruser,anotheruser,yetanotheruser</i>
+        </div>
+    </l:ajax>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/help-committersToIgnore.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/help-committersToIgnore.jelly
@@ -6,13 +6,13 @@
                 A comma-delimited list of usernames to ignore push events from. These events will be handled
                 and logged by the plugin but will not trigger builds. The obvious use-case for this is
                 ignoring push events by a designated Jenkins git user, so that your builds don't trigger
-                more builds.
-    
-                This must <b>exactly</b> match their Github username.
-
-                Examples:
-                <i>jenkinsuser</i>
-                <i>jenkinsuser,otheruser,anotheruser,yetanotheruser</i>
+                more builds.<br/>
+                <br/>
+                This must <b>exactly</b> match their Github username.<br/>
+                <br/>
+                Examples:<br/>
+                <i>jenkinsuser</i><br/>
+                <i>jenkinsuser,otheruser,anotheruser,yetanotheruser</i><br/>
             </p>
         </div>
     </l:ajax>

--- a/src/test/java/com/cloudbees/jenkins/GlobalConfigSubmitTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GlobalConfigSubmitTest.java
@@ -26,8 +26,10 @@ public class GlobalConfigSubmitTest {
 
     public static final String OVERRIDE_HOOK_URL_CHECKBOX = "_.overrideHookUrl";
     public static final String HOOK_URL_INPUT = "_.hookUrl";
+    public static final String COMMITTERS_TO_IGNORE_INPUT = "_.committersToIgnore";
 
     private static final String WEBHOOK_URL = "http://jenkinsci.example.com/jenkins/github-webhook/";
+    private static final String COMMITTERS_TO_IGNORE = "lanwen,dbsanfte";
 
     @Rule
     public JenkinsRule jenkins = new JenkinsRule();
@@ -42,6 +44,18 @@ public class GlobalConfigSubmitTest {
 
         assertThat(GitHubPlugin.configuration().isOverrideHookURL(), is(true));
         assertThat(GitHubPlugin.configuration().getHookUrl(), equalTo(new URL(WEBHOOK_URL)));
+    }
+
+    @Test
+    public void shouldSetIgnorableCommittersField() throws Exception {
+        HtmlForm form = globalConfig();
+
+        form.getInputByName(COMMITTERS_TO_IGNORE_INPUT).setValueAttribute(COMMITTERS_TO_IGNORE);
+        jenkins.submit(form);
+
+        assertThat(GitHubPlugin.configuration().getCommittersToIgnore(), is(COMMITTERS_TO_IGNORE));
+        assertThat(GitHubPlugin.configuration().getCommittersToIgnoreArray()[0], is(COMMITTERS_TO_IGNORE.split(",")[0]));
+        assertThat(GitHubPlugin.configuration().getCommittersToIgnoreArray()[1], is(COMMITTERS_TO_IGNORE.split(",")[1]));
     }
 
     public HtmlForm globalConfig() throws IOException, SAXException {


### PR DESCRIPTION
Support for ignoring push events from certain Github usernames. The obvious use case is ignoring push events from a Jenkins user and keeping them from re-triggering builds.

Tests + help files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/182)
<!-- Reviewable:end -->
