### PR TITLE
[JENKINS-47820] Update github-api dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.86</version>
+            <version>1.90</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Updating org.jenkins-ci.plugins.github-api to the newest version should resolve an issue JENKINS-47820 about parsing large IDs from github.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/183)
<!-- Reviewable:end -->
