### PR TITLE
Restore source compatibility of GitHub plugin after #183

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubRepositoryName.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubRepositoryName.java
@@ -12,6 +12,7 @@ import org.jenkinsci.plugins.github.config.GitHubServerConfig;
 import org.jenkinsci.plugins.github.util.misc.NullSafeFunction;
 import org.kohsuke.github.GHCommitPointer;
 import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitHub;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -180,7 +181,15 @@ public class GitHubRepositoryName {
      * Does this repository match the repository referenced in the given {@link GHCommitPointer}?
      */
     public boolean matches(GHCommitPointer commit) {
-        return userName.equals(commit.getUser().getLogin())
+        final GHUser user;
+        try {
+            user = commit.getUser();
+        } catch (IOException ex) {
+            LOGGER.debug("Failed to extract user from commit " + commit, ex);
+            return false;
+        }
+
+        return userName.equals(user.getLogin())
                 && repositoryName.equals(commit.getRepository().getName())
                 && host.equals(commit.getRepository().getHtmlUrl().getHost());
     }


### PR DESCRIPTION
The `GHCommitPointer#getUser()` method signature changed in GitHub API 1.89 (see https://github.com/kohsuke/github-api/commit/9f3f644b83ec002cf4e7b58c1a7b79f803757d7c). The plugin won't build somehow, it seem #183 has been merged without checking the CI report

@reviewbybees @lanwen @KostyaSha

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/186)
<!-- Reviewable:end -->
