### PR TITLE
Update Parent POM to 2.37 and use Apache HttpComponents API 4.x plugin 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,9 +154,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.2</version>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>apache-httpcomponents-client-4-api</artifactId>
+            <version>4.5.3-2.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.6</version>
+        <version>2.37</version>
         <relativePath />
     </parent>
 
@@ -48,13 +48,12 @@
 
     <properties>
         <jenkins.version>1.625.3</jenkins.version>
-        <jenkins-test-harness.version>1.625.3</jenkins-test-harness.version>
         <release.skipTests>false</release.skipTests>
         <maven.javadoc.skip>true</maven.javadoc.skip>
-        <findbugs-maven-plugin.version>3.0.2</findbugs-maven-plugin.version>
+        <!-- TODO: Use stock Parent POM 3.2+ and use findbugs.threshold/findbugs.level there -->
+        <findbugs-maven-plugin.version>3.0.5</findbugs-maven-plugin.version>
         <concurrency>1</concurrency>
         <java.level>7</java.level>
-        <hpi-plugin.version>1.120</hpi-plugin.version>
         <workflow.version>1.14.2</workflow.version>
     </properties>
 
@@ -113,13 +112,13 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.8</version>
+            <version>2.1.13</version>
         </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
-            <version>1.1</version>
+            <version>1.4</version>
         </dependency>
 
         <dependency>
@@ -143,7 +142,7 @@
         <dependency><!-- exists in the core -->
             <groupId>org.jenkins-ci.modules</groupId>
             <artifactId>instance-identity</artifactId>
-            <version>1.3</version>
+            <version>1.4</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
I was running PCT against the plugin and hit some issues with that.

- [x] - Update Parent POM and resolve upper bound dependency issues
- [x] - Switch to https://github.com/jenkinsci/apache-httpcomponents-client-4-api-plugin so that GitHubWebHookFullTest does not blow up with `ON: NoClassDefFoundError: Could not initialize class com.jayway.restassured.RestAssured` due to the missing httpmime dependency

@reviewbybees @lanwen @KostyaSha @raul-arabaolaza

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/187)
<!-- Reviewable:end -->
