### PR TITLE
Prevent stacktrace when there are no admin credentials

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github/webhook/WebhookManager.java
+++ b/src/main/java/org/jenkinsci/plugins/github/webhook/WebhookManager.java
@@ -176,10 +176,12 @@ public class WebhookManager {
             @Override
             protected GHHook applyNullSafe(@Nonnull GitHubRepositoryName name) {
                 try {
-                    GHRepository repo = checkNotNull(
-                            from(name.resolve(allowedToManageHooks())).firstMatch(withAdminAccess()).orNull(),
-                            "There is no credentials with admin access to manage hooks on %s", name
-                    );
+                    GHRepository repo = from(name.resolve(allowedToManageHooks())).firstMatch(withAdminAccess())
+                            .orNull();
+                    if (repo == null) {
+                        LOGGER.warn("There is no credentials with admin access to manage hooks on {}", name);
+                        return null;
+                    }
 
                     Validate.notEmpty(events, "Events list for hook can't be empty");
 


### PR DESCRIPTION
To keep logs cleaner

Instead of

```
Dec 10, 2016 10:31:51 PM WARNING org.jenkinsci.plugins.github.webhook.WebhookManager$2 applyNullSafe
Failed to add GitHub webhook for GitHubRepositoryName[host=github.com,username=doublesharp,repository=PRIVATE_PROJECT]
java.lang.NullPointerException: There is no credentials with admin access to manage hooks on GitHubRepositoryName[host=github.com,username=doublesharp,repository=PRIVATE_PROJECT]
	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:231)
	at org.jenkinsci.plugins.github.webhook.WebhookManager$2.applyNullSafe(WebhookManager.java:156)
	at org.jenkinsci.plugins.github.webhook.WebhookManager$2.applyNullSafe(WebhookManager.java:152)
	at org.jenkinsci.plugins.github.util.misc.NullSafeFunction.apply(NullSafeFunction.java:18)
```