### PR TITLE
Fix typo in GitHub hook problem message

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/github/admin/GitHubHookRegisterProblemMonitor/message.properties
+++ b/src/main/resources/org/jenkinsci/plugins/github/admin/GitHubHookRegisterProblemMonitor/message.properties
@@ -1,3 +1,3 @@
 view=View
 dismiss=Dismiss
-hook.registering.problem=There were some problems while registering or removing one ore more GitHub webhooks. Would you like to view the problems?
+hook.registering.problem=There were some problems while registering or removing one or more GitHub webhooks. Would you like to view the problems?


### PR DESCRIPTION
Just fixing a very small (but quite prominent) typo in an error message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/192)
<!-- Reviewable:end -->
