### PR TITLE
Adds retry mechanism to applyNullSafe method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <jenkins-test-harness.version>1.625.3</jenkins-test-harness.version>
         <release.skipTests>false</release.skipTests>
         <maven.javadoc.skip>true</maven.javadoc.skip>
-        <findbugs-maven-plugin.version>3.0.2</findbugs-maven-plugin.version>
+        <findbugs-maven-plugin.version>3.0.5</findbugs-maven-plugin.version>
         <concurrency>1</concurrency>
         <java.level>7</java.level>
         <hpi-plugin.version>1.120</hpi-plugin.version>

--- a/src/main/java/com/cloudbees/jenkins/GitHubRepositoryName.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubRepositoryName.java
@@ -4,7 +4,6 @@ import com.coravy.hudson.plugins.github.GithubProjectProperty;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
-import com.google.common.collect.Iterables;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -229,15 +228,16 @@ public class GitHubRepositoryName {
             @Override
             protected GHRepository applyNullSafe(@Nonnull GitHub gitHub) {
                 int mtries = 0;
-                while(mtries < MAX_RETRIES){
+                while (mtries < MAX_RETRIES) {
                     try {
-                        return gitHub.getRepository(format("%s/%s", repoName.getUserName(), repoName.getRepositoryName()));
-                    } catch (UnknownHostException e){
+                        return gitHub.getRepository(format("%s/%s", repoName.getUserName(),
+                                repoName.getRepositoryName()));
+                    } catch (UnknownHostException e) {
                         LOGGER.warn("Failed to resolve repository {}", this, e);
                         mtries++;
                         try {
                             Thread.sleep(BACKOFF_MILLIS * mtries);
-                        } catch(InterruptedException ex) {
+                        } catch (InterruptedException ex) {
                             LOGGER.error("{}", this, ex);
                         }
                     } catch (IOException e) {


### PR DESCRIPTION
While using the plugin for our CI system, we have noticed that on some rare occasions it fails to resolve the URL of the GitHub repository. This problem results in the following message (in normal conditions, _repos_ would not be empty):

> [Set GitHub commit status (universal)] SUCCESS on repos [] (sha:90a0bd0) with context: context

The full trace is this one:

`
Jan 20, 2019 1:31:46 PM WARNING com.cloudbees.jenkins.GitHubRepositoryName$1 applyNullSafe
Failed to obtain repository com.cloudbees.jenkins.GitHubRepositoryName$1@6647d12d
java.net.UnknownHostException: api.github.com: Name or service not known
    at java.net.Inet6AddressImpl.lookupAllHostAddr(Native Method)
    at java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:929)
    at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:1324)
    at java.net.InetAddress.getAllByName0(InetAddress.java:1277)
    at java.net.InetAddress.getAllByName(InetAddress.java:1193)
    at java.net.InetAddress.getAllByName(InetAddress.java:1127)
    at com.squareup.okhttp.Dns$1.lookup(Dns.java:39)
    at com.squareup.okhttp.internal.http.RouteSelector.resetNextInetSocketAddress(RouteSelector.java:175)
    at com.squareup.okhttp.internal.http.RouteSelector.nextProxy(RouteSelector.java:141)
    at com.squareup.okhttp.internal.http.RouteSelector.next(RouteSelector.java:83)
    at com.squareup.okhttp.internal.http.StreamAllocation.findConnection(StreamAllocation.java:174)
    at com.squareup.okhttp.internal.http.StreamAllocation.findHealthyConnection(StreamAllocation.java:126)
    at com.squareup.okhttp.internal.http.StreamAllocation.newStream(StreamAllocation.java:95)
    at com.squareup.okhttp.internal.http.HttpEngine.connect(HttpEngine.java:281)
    at com.squareup.okhttp.internal.http.HttpEngine.sendRequest(HttpEngine.java:224)
    at com.squareup.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:450)
    at com.squareup.okhttp.internal.huc.HttpURLConnectionImpl.getResponse(HttpURLConnectionImpl.java:399)
    at com.squareup.okhttp.internal.huc.HttpURLConnectionImpl.getResponseCode(HttpURLConnectionImpl.java:527)
    at com.squareup.okhttp.internal.huc.DelegatingHttpsURLConnection.getResponseCode(DelegatingHttpsURLConnection.java:105)
    at com.squareup.okhttp.internal.huc.HttpsURLConnectionImpl.getResponseCode(HttpsURLConnectionImpl.java:25)
    at org.kohsuke.github.Requester.parse(Requester.java:615)
Caused: org.kohsuke.github.HttpException: Server returned HTTP response code: -1, message: 'null' for URL: https://api.github.com/repos/apache/incubator-mxnet
    at org.kohsuke.github.Requester.parse(Requester.java:646)
    at org.kohsuke.github.Requester.parse(Requester.java:607)
    at org.kohsuke.github.Requester._to(Requester.java:285)
    at org.kohsuke.github.Requester.to(Requester.java:247)
    at org.kohsuke.github.GitHub.getRepository(GitHub.java:475)
    at com.cloudbees.jenkins.GitHubRepositoryName$1.applyNullSafe(GitHubRepositoryName.java:227)
    at com.cloudbees.jenkins.GitHubRepositoryName$1.applyNullSafe(GitHubRepositoryName.java:223)
    at org.jenkinsci.plugins.github.util.misc.NullSafeFunction.apply(NullSafeFunction.java:18)
    at com.google.common.collect.Iterators$8.next(Iterators.java:812)
    at com.google.common.collect.Iterators$7.computeNext(Iterators.java:648)
    at com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:143)
    at com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:138)
    at com.google.common.collect.Iterators$5.hasNext(Iterators.java:543)
    at com.google.common.collect.Lists.newArrayList(Lists.java:138)
    at com.google.common.collect.Lists.newArrayList(Lists.java:119)
    at org.jenkinsci.plugins.github.util.FluentIterableWrapper.toList(FluentIterableWrapper.java:147)
    at org.jenkinsci.plugins.github.status.sources.ManuallyEnteredRepositorySource.repos(ManuallyEnteredRepositorySource.java:51)
    at org.jenkinsci.plugins.github.status.GitHubCommitStatusSetter.perform(GitHubCommitStatusSetter.java:136)
    at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:80)
    at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:67)
    at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution$1$1.call(SynchronousNonBlockingStepExecution.java:51)
    at hudson.security.ACL.impersonate(ACL.java:290)
    at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution$1.run(SynchronousNonBlockingStepExecution.java:48)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)
`

This PR wraps applyNullSafe with a retry mechanism with linear backoff as a solution for the problem.