### PR TITLE
[JENKINS-55787] Switch labels from entry to checkbox

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubServerConfig/config.groovy
@@ -26,9 +26,8 @@ f.block() {
     )
 }
 
-
-f.entry(title: _("Manage hooks"), field: "manageHooks") {
-    f.checkbox(default: true)
+f.entry() {
+    f.checkbox(title: _("Manage hooks"), field: "manageHooks")
 }
 
 f.advanced() {


### PR DESCRIPTION
[https://issues.jenkins-ci.org/browse/JENKINS-55787](https://issues.jenkins-ci.org/browse/JENKINS-55787)

Basically checkboxes should have labels, splitting the labels away from their checkboxes is poor UX, poor accessibility. This change brings the layout more inline with how normal settings UIs lay out checkboxes.

This supersedes #203

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/207)
<!-- Reviewable:end -->
