### PR TITLE
[JENKINS-56830] alternative use of 'html_url' in payload of event

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventSubscriber.java
+++ b/src/main/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventSubscriber.java
@@ -76,7 +76,22 @@ public class DefaultPushGHEventSubscriber extends GHEventsSubscriber {
         URL repoUrl = push.getRepository().getUrl();
         final String pusherName = push.getPusher().getName();
         LOGGER.info("Received PushEvent for {} from {}", repoUrl, event.getOrigin());
-        final GitHubRepositoryName changedRepository = GitHubRepositoryName.create(repoUrl.toExternalForm());
+        GitHubRepositoryName fromEventRepository = GitHubRepositoryName.create(repoUrl.toExternalForm());
+
+        if (fromEventRepository == null) {
+            // On push event on github.com url === html_url
+            // this is not consistent with the API docs and with hosted repositories
+            // see https://goo.gl/c1qmY7
+            // let's retry with 'html_url'
+            URL htmlUrl = push.getRepository().getHtmlUrl();
+            fromEventRepository = GitHubRepositoryName.create(htmlUrl.toExternalForm());
+            if (fromEventRepository != null) {
+                LOGGER.debug("PushEvent handling: 'html_url' field "
+                        + "has been used to retrieve project information (instead of default 'url' field)");
+            }
+        }
+
+        final GitHubRepositoryName changedRepository = fromEventRepository;
 
         if (changedRepository != null) {
             // run in high privilege to see all the projects anonymous users don't see.


### PR DESCRIPTION
As documented in github API docs (https://developer.github.com/v3/repos/#response) the url field of the event should/could point to the API endpoint.
In the github-plugin it is expected to work on the public html url which is handled by the 'html_url' field of the event.
This commit thus try as before to build a GitHubRepositoryName from the 'url' field ; if that fails, as a fallback it also tries the 'html_url' field.
See also https://github.community/t5/GitHub-API-Development-and/consistency-of-repository-url-between-event-types/td-p/21209 for some explanations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/212)
<!-- Reviewable:end -->
