### PR TITLE
add support for git+ssh:// urls

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubRepositoryName.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubRepositoryName.java
@@ -50,7 +50,7 @@ public class GitHubRepositoryName {
             Pattern.compile("https?://[^/]+@([^/]+)/([^/]+)/([^/]+)\\.git(?:/)?"),
             Pattern.compile("https?://([^/]+)/([^/]+)/([^/]+)\\.git(?:/)?"),
             Pattern.compile("git://([^/]+)/([^/]+)/([^/]+)\\.git(?:/)?"),
-            Pattern.compile("ssh://(?:git@)?([^/]+)/([^/]+)/([^/]+)\\.git(?:/)?"),
+            Pattern.compile("(?:git\\+)?ssh://(?:git@)?([^/]+)/([^/]+)/([^/]+)\\.git(?:/)?"),
             /**
              * The second set of patterns extract the host, owner and repository names
              * from all other URLs. Note that these patterns must be processed *after*
@@ -61,7 +61,7 @@ public class GitHubRepositoryName {
             Pattern.compile("https?://[^/]+@([^/]+)/([^/]+)/([^/]+)/?"),
             Pattern.compile("https?://([^/]+)/([^/]+)/([^/]+)/?"),
             Pattern.compile("git://([^/]+)/([^/]+)/([^/]+)/?"),
-            Pattern.compile("ssh://(?:git@)?([^/]+)/([^/]+)/([^/]+)/?")
+            Pattern.compile("(?:git\\+)?ssh://(?:git@)?([^/]+)/([^/]+)/([^/]+)/?"),
     };
 
     /**

--- a/src/test/java/com/coravy/hudson/plugins/github/GitHubRepositoryNameTest.java
+++ b/src/test/java/com/coravy/hudson/plugins/github/GitHubRepositoryNameTest.java
@@ -64,6 +64,8 @@ public class GitHubRepositoryNameTest {
             "ssh://github.com/jenkinsci/jenkins.git, github.com, jenkinsci, jenkins",
             "ssh://github.com/jenkinsci/jenkins, github.com, jenkinsci, jenkins",
             "ssh://github.com/jenkinsci/jenkins/, github.com, jenkinsci, jenkins",
+            "git+ssh://git@github.com/jenkinsci/jenkins.git, github.com, jenkinsci, jenkins",
+            "git+ssh://github.com/jenkinsci/jenkins, github.com, jenkinsci, jenkins",
     })
     public void githubFullRepo(String url, String host, String user, String repo) {
         assertThat(url, repo(allOf(


### PR DESCRIPTION
I did not looked deeply into it. I don't know, why the pattern is not already matching against git+ssh://.
But from testing, removing the "git+" triggers correctly github webhook, while with it, it does not match the repository.

This is an RFC, it's not even compile tested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/213)
<!-- Reviewable:end -->
