### PR TITLE
Also use GitHub Project property for webhooks

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubRepositoryNameContributor.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubRepositoryNameContributor.java
@@ -126,20 +126,23 @@ public abstract class GitHubRepositoryNameContributor implements ExtensionPoint 
     public static class FromSCM extends GitHubRepositoryNameContributor {
         @Override
         public void parseAssociatedNames(Item item, Collection<GitHubRepositoryName> result) {
-            // extract the GitHub project URL as defined under General job properties
-            Job job = (Job) item;
-            GithubProjectProperty ghpp = (GithubProjectProperty) job.getProperty(GithubProjectProperty.class);
-            GitHubRepositoryName githubrepo = GitHubRepositoryName.create(ghpp.getProjectUrl().toString());
-
             SCMTriggerItem triggerItem = SCMTriggerItems.asSCMTriggerItem(item);
             EnvVars envVars = item instanceof Job ? buildEnv((Job) item) : new EnvVars();
             if (triggerItem != null) {
                 for (SCM scm : triggerItem.getSCMs()) {
                     addRepositories(scm, envVars, result);
                 }
-                // additionally add the explicit GitHub project URL to the result collection
+                // additionally add the explicit GitHub project URL as defined
+                // under General job properties to the result collection
                 // as it may differ from the SCM URL due to proxy usage
-                result.add(githubrepo);
+                Job job = (Job) item;
+                GithubProjectProperty ghpp = (GithubProjectProperty) job.getProperty(GithubProjectProperty.class);
+                if (ghpp != null) {
+                    GitHubRepositoryName githubrepo = GitHubRepositoryName.create(ghpp.getProjectUrl().toString());
+                    if (githubrepo != null) {
+                        result.add(githubrepo);
+                    }
+                }
             }
         }
 

--- a/src/main/resources/com/cloudbees/jenkins/GitHubPushTrigger/help.html
+++ b/src/main/resources/com/cloudbees/jenkins/GitHubPushTrigger/help.html
@@ -1,2 +1,3 @@
-If Jenkins will receive PUSH GitHub hook from repo defined in Git SCM section it
-will trigger Git SCM polling logic. So polling logic in fact belongs to Git SCM.
+If Jenkins receives a PUSH GitHub hook matching the repo defined in the Git SCM
+section or in GitHub project -> Project url, it will trigger the Git SCM polling
+logic. So the polling logic in fact belongs to Git SCM.


### PR DESCRIPTION
It is possible for one to be in a situation where the SCM address used by Jenkins for cloning doesn't exactly match the address advertised by github in its webhooks.  E.g. your github enterprise installation thinks its name is github.corporate.internal, an address perhaps reachable from a user's desktop but not from your jenkins slave, which must use github.proxy.com.

This PR tells the jenkins webhook receiver to consider the Github Project property field **in addition to** the SCM field when considering candidates to "poke", thus it's safe and shouldn't break existing usage.  Note that the [Github Pull Request Builder](https://github.com/jenkinsci/ghprb-plugin) plugin seems to use the Github Project property field exclusively rather than the SCM field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/214)
<!-- Reviewable:end -->
