### PR TITLE
Update github-api version. Excludes for jackson. Bump findbugs version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <jenkins.version>2.60.3</jenkins.version>
         <release.skipTests>false</release.skipTests>
         <maven.javadoc.skip>true</maven.javadoc.skip>
-        <findbugs-maven-plugin.version>3.0.2</findbugs-maven-plugin.version>
+        <findbugs-maven-plugin.version>3.0.4</findbugs-maven-plugin.version>
         <concurrency>1</concurrency>
         <java.level>8</java.level>
         <workflow.version>1.14.2</workflow.version>
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.90</version>
+            <version>1.95</version>
         </dependency>
 
         <dependency>
@@ -249,6 +249,18 @@
                 <exclusion>
                     <groupId>net.sf.jopt-simple</groupId>
                     <artifactId>jopt-simple</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
* Dependency update for github-api
* Excludes added for `jackson-annotations`, `jackson-core`, and `jackson-databind`, which are here via (test-scoped) wiremock libraries. 
* This brought with it a version bump for findbugs. I'm running Maven 3.6.0 locally, so following [this article](https://stackoverflow.com/questions/53676071/maven-clean-command-java-util-collections-unmodifiablerandomaccesslist-to-prope), I bumped to 3.0.4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/215)
<!-- Reviewable:end -->
