### PR TITLE
Enable Release Drafter for the repository

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,5 @@
+# https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
+_extends: .github
+version-template: $MAJOR.$MINOR.$PATCH
+tag-template: github-$NEXT_PATCH_VERSION
+name-template: $NEXT_PATCH_VERSION

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
 # https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
 _extends: .github
 version-template: $MAJOR.$MINOR.$PATCH
-tag-template: github-$NEXT_PATCH_VERSION
-name-template: $NEXT_PATCH_VERSION
+tag-template: v$NEXT_PATCH_VERSION
+name-template: v$NEXT_PATCH_VERSION


### PR DESCRIPTION
@lanwen was using GitHub releases for last releases anyway. Why don't we automate it?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/218)
<!-- Reviewable:end -->
