### PR TITLE
Upgrade to github-api 1.114 and okhttp3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.57</version>
+        <version>4.2</version>
         <relativePath />
     </parent>
 
@@ -47,7 +47,7 @@
     </issueManagement>
 
     <properties>
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>2.164.3</jenkins.version>
         <release.skipTests>false</release.skipTests>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <findbugs-maven-plugin.version>3.0.4</findbugs-maven-plugin.version>
@@ -80,22 +80,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-            <version>${slf4jVersion}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.okhttp</groupId>
-            <artifactId>okhttp-urlconnection</artifactId>
-            <version>2.7.5</version>
-            <optional>false</optional>
-        </dependency>
-
-        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.90</version>
+            <version>1.114.2</version>
         </dependency>
 
         <dependency>
@@ -143,14 +130,14 @@
         <dependency>
             <groupId>org.jenkins-ci.modules</groupId>
             <artifactId>instance-identity</artifactId>
-            <version>2.1</version><!-- Version matches https://mvnrepository.com/artifact/org.jenkins-ci.main/jenkins-war/2.60.3 -->
+            <version>2.2</version>
             <scope>provided</scope><!-- https://wiki.jenkins.io/display/JENKINS/Instance+Identity "add a provided scope dependency to this module into your plugin" -->
         </dependency>
 
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope><!-- Provided by core: https://mvnrepository.com/artifact/org.jenkins-ci.main/jenkins-core/2.60.3 -->
+            <scope>provided</scope>
         </dependency>
 
         <!--TEST DEPS-->
@@ -311,6 +298,16 @@
         </dependency>
 
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jenkins-ci</groupId>
+                <artifactId>annotation-indexer</artifactId>
+                <version>1.12</version>
+            </dependency>    
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.54</version>
+        <version>3.57</version>
         <relativePath />
     </parent>
 
@@ -51,6 +51,7 @@
         <release.skipTests>false</release.skipTests>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <findbugs-maven-plugin.version>3.0.4</findbugs-maven-plugin.version>
+        <hamcrest.version>2.2</hamcrest.version>
         <concurrency>1</concurrency>
         <java.level>8</java.level>
         <workflow.version>1.14.2</workflow.version>
@@ -75,7 +76,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.7</version>
+            <version>3.9</version>    
         </dependency>
 
         <dependency>
@@ -162,26 +163,31 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- 1.3 used by rest-assured -->
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- This is needed in order to force junit4 and JTH tests to use newer hamcrest version -->
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
-            <version>2.1</version>
+            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
 
-        <!-- 1.3 used by rest-assured -->
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-            <version>2.1</version>
+            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
-
+      
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/org/jenkinsci/plugins/github/internal/GitHubClientCacheOps.java
+++ b/src/main/java/org/jenkinsci/plugins/github/internal/GitHubClientCacheOps.java
@@ -4,7 +4,8 @@ import com.cloudbees.jenkins.GitHubWebHook;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.hash.Hashing;
-import com.squareup.okhttp.Cache;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import okhttp3.Cache;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.github.GitHubPlugin;
 import org.jenkinsci.plugins.github.config.GitHubServerConfig;
@@ -94,6 +95,7 @@ public final class GitHubClientCacheOps {
      *
      * @param configs active server configs to exclude caches from cleanup
      */
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     public static void clearRedundantCaches(List<GitHubServerConfig> configs) {
         Path baseCacheDir = getBaseCacheDir();
 
@@ -170,7 +172,7 @@ public final class GitHubClientCacheOps {
     private static class CacheToName extends NullSafeFunction<Cache, String> {
         @Override
         protected String applyNullSafe(@Nonnull Cache cache) {
-            return cache.getDirectory().getName();
+            return cache.directory().getName();
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/github/util/JobInfoHelpers.java
+++ b/src/main/java/org/jenkinsci/plugins/github/util/JobInfoHelpers.java
@@ -9,11 +9,13 @@ import hudson.model.BuildableItem;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.triggers.Trigger;
+import hudson.triggers.TriggerDescriptor;
 import jenkins.model.ParameterizedJobMixIn;
 import org.jenkinsci.plugins.github.extension.GHEventsSubscriber;
 
 import javax.annotation.CheckForNull;
 import java.util.Collection;
+import java.util.Map;
 
 import static org.jenkinsci.plugins.github.extension.GHEventsSubscriber.isApplicableFor;
 import static org.jenkinsci.plugins.github.util.FluentIterableWrapper.from;
@@ -111,7 +113,8 @@ public final class JobInfoHelpers {
         if (item instanceof ParameterizedJobMixIn.ParameterizedJob) {
             ParameterizedJobMixIn.ParameterizedJob pJob = (ParameterizedJobMixIn.ParameterizedJob) item;
 
-            for (Trigger candidate : pJob.getTriggers().values()) {
+            Map<TriggerDescriptor, Trigger<?>> triggerMap = pJob.getTriggers();
+            for (Trigger candidate : triggerMap.values()) {
                 if (tClass.isInstance(candidate)) {
                     return tClass.cast(candidate);
                 }

--- a/src/test/java/org/jenkinsci/plugins/github/internal/GitHubClientCacheOpsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/internal/GitHubClientCacheOpsTest.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.plugins.github.internal;
 
-import com.squareup.okhttp.Cache;
+import okhttp3.Cache;
 import org.jenkinsci.plugins.github.config.GitHubServerConfig;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -43,7 +43,7 @@ public class GitHubClientCacheOpsTest {
         Cache cache2 = toCacheDir().apply(config);
 
         assertThat("same config should get same cache",
-                cache1.getDirectory().getAbsolutePath(), equalTo(cache2.getDirectory().getAbsolutePath()));
+                cache1.directory().getAbsolutePath(), equalTo(cache2.directory().getAbsolutePath()));
     }
 
     @Test
@@ -57,7 +57,7 @@ public class GitHubClientCacheOpsTest {
         Cache cache2 = toCacheDir().apply(config2);
 
         assertThat("with changed url",
-                cache1.getDirectory().getAbsolutePath(), not(cache2.getDirectory().getAbsolutePath()));
+                cache1.directory().getAbsolutePath(), not(cache2.directory().getAbsolutePath()));
     }
 
     @Test
@@ -69,7 +69,7 @@ public class GitHubClientCacheOpsTest {
         Cache cache2 = toCacheDir().apply(config2);
 
         assertThat("with changed creds",
-                cache1.getDirectory().getAbsolutePath(), not(cache2.getDirectory().getAbsolutePath()));
+                cache1.directory().getAbsolutePath(), not(cache2.directory().getAbsolutePath()));
     }
 
     @Test


### PR DESCRIPTION
@KostyaSha 
This change updates github-plugi to use okhttp3. Okhttp 2.7.5 is seriously out of date and no longer supported. We should move to using okhttp3.

@KostyaSha @lanwen  

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/228)
<!-- Reviewable:end -->
