### PR TITLE
Update previously used name for Github trigger option

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/help.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/help.jelly
@@ -8,7 +8,7 @@
                 This plugin doesn't do anything with the GitHub API unless you add a configuration with credentials.
                 So if you don't want to add any configuration, you can set up hooks for this Jenkins instance manually.
                 <br/>
-                In this mode, in addition to configuring projects with "<i>Build when a change is pushed to GitHub</i>",
+                In this mode, in addition to configuring projects with "<i>GitHub hook trigger for GITScm polling</i>",
                 you need to ensure that Jenkins gets a POST to its
                 <tt><a href="${rootURL}/github-webhook/">${app.rootUrl}github-webhook/</a></tt>.
             </p>


### PR DESCRIPTION
This name looks like it was changed from "Build when a change is pushed to GitHub" to "GitHub hook trigger for GITScm polling" a few years ago.

However in Configure System under the Github plugin it still has the wrong text when clicking the help button.

![image](https://user-images.githubusercontent.com/27447/81446596-3705f980-9149-11ea-8903-d21f5fb75fe0.png)

This confused me today and looks like it's been confusing for a few years now from [Stack Overflow](https://stackoverflow.com/questions/30576881/jenkins-build-when-a-change-is-pushed-to-github-option-is-not-working)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/231)
<!-- Reviewable:end -->
