### PR TITLE
Fix typo on docs url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <packaging>hpi</packaging>
 
     <name>GitHub plugin</name>
-    <url>https://github.com/jenkinsci/github</url>
+    <url>https://github.com/jenkinsci/github-plugin</url>
     <licenses>
         <license>
             <name>MIT License</name>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/232)
<!-- Reviewable:end -->
