### PR TITLE
[Fix JENKINS-62339] - Allow multibranch pipelines to configure GitHub project URL

### DIFF
--- a/src/main/java/com/coravy/hudson/plugins/github/GithubProjectProperty.java
+++ b/src/main/java/com/coravy/hudson/plugins/github/GithubProjectProperty.java
@@ -116,8 +116,7 @@ public final class GithubProjectProperty extends JobProperty<Job<?, ?>> {
         }
 
         @Override
-        public JobProperty<?> newInstance(@Nonnull StaplerRequest req, JSONObject formData)
-                throws Descriptor.FormException {
+        public JobProperty<?> newInstance(@Nonnull StaplerRequest req, JSONObject formData) throws FormException {
             GithubProjectProperty tpp = req.bindJSON(
                     GithubProjectProperty.class,
                     formData.getJSONObject(GITHUB_PROJECT_BLOCK_NAME)

--- a/src/main/java/com/coravy/hudson/plugins/github/GithubProjectProperty.java
+++ b/src/main/java/com/coravy/hudson/plugins/github/GithubProjectProperty.java
@@ -116,7 +116,9 @@ public final class GithubProjectProperty extends JobProperty<Job<?, ?>> {
         }
 
         @Override
-        public JobProperty<?> newInstance(@Nonnull StaplerRequest req, JSONObject formData) throws Descriptor.FormException {
+        public JobProperty<?> newInstance(@Nonnull StaplerRequest req,
+		                                  JSONObject formData) throws Descriptor.FormException {
+
             GithubProjectProperty tpp = req.bindJSON(
                     GithubProjectProperty.class,
                     formData.getJSONObject(GITHUB_PROJECT_BLOCK_NAME)

--- a/src/main/java/com/coravy/hudson/plugins/github/GithubProjectProperty.java
+++ b/src/main/java/com/coravy/hudson/plugins/github/GithubProjectProperty.java
@@ -116,7 +116,7 @@ public final class GithubProjectProperty extends JobProperty<Job<?, ?>> {
         }
 
         @Override
-        public JobProperty<?> newInstance(@Nonnull StaplerRequest req, JSONObject formData) throws FormException {
+        public JobProperty<?> newInstance(@Nonnull StaplerRequest req, JSONObject formData) throws Descriptor.FormException {
             GithubProjectProperty tpp = req.bindJSON(
                     GithubProjectProperty.class,
                     formData.getJSONObject(GITHUB_PROJECT_BLOCK_NAME)

--- a/src/main/java/com/coravy/hudson/plugins/github/GithubProjectProperty.java
+++ b/src/main/java/com/coravy/hudson/plugins/github/GithubProjectProperty.java
@@ -117,7 +117,7 @@ public final class GithubProjectProperty extends JobProperty<Job<?, ?>> {
 
         @Override
         public JobProperty<?> newInstance(@Nonnull StaplerRequest req,
-		                                  JSONObject formData) throws Descriptor.FormException {
+                                          JSONObject formData) throws Descriptor.FormException {
 
             GithubProjectProperty tpp = req.bindJSON(
                     GithubProjectProperty.class,

--- a/src/main/java/com/coravy/hudson/plugins/github/GithubProjectProperty.java
+++ b/src/main/java/com/coravy/hudson/plugins/github/GithubProjectProperty.java
@@ -99,7 +99,7 @@ public final class GithubProjectProperty extends JobProperty<Job<?, ?>> {
     }
 
     @Extension
-    @Symbol("githubProjectProperties")
+    @Symbol("githubProjectProperty")
     public static final class DescriptorImpl extends JobPropertyDescriptor {
         /**
          * Used to hide property configuration under checkbox,

--- a/src/main/java/com/coravy/hudson/plugins/github/GithubProjectProperty.java
+++ b/src/main/java/com/coravy/hudson/plugins/github/GithubProjectProperty.java
@@ -1,7 +1,7 @@
 package com.coravy.hudson.plugins.github;
 
-import com.cloudbees.jenkins.GitHubPushTrigger;
 import hudson.Extension;
+import hudson.model.Descriptor;
 import hudson.model.Job;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
@@ -13,6 +13,7 @@ import org.kohsuke.stapler.StaplerRequest;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import org.jenkinsci.Symbol;
 import java.util.logging.Logger;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -98,6 +99,7 @@ public final class GithubProjectProperty extends JobProperty<Job<?, ?>> {
     }
 
     @Extension
+    @Symbol("githubProjectProperties")
     public static final class DescriptorImpl extends JobPropertyDescriptor {
         /**
          * Used to hide property configuration under checkbox,
@@ -114,7 +116,8 @@ public final class GithubProjectProperty extends JobProperty<Job<?, ?>> {
         }
 
         @Override
-        public JobProperty<?> newInstance(@Nonnull StaplerRequest req, JSONObject formData) throws FormException {
+        public JobProperty<?> newInstance(@Nonnull StaplerRequest req, JSONObject formData)
+                throws Descriptor.FormException {
             GithubProjectProperty tpp = req.bindJSON(
                     GithubProjectProperty.class,
                     formData.getJSONObject(GITHUB_PROJECT_BLOCK_NAME)
@@ -135,5 +138,5 @@ public final class GithubProjectProperty extends JobProperty<Job<?, ?>> {
 
     }
 
-    private static final Logger LOGGER = Logger.getLogger(GitHubPushTrigger.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(GithubProjectProperty.class.getName());
 }


### PR DESCRIPTION
This PR fixes the following issue https://issues.jenkins-ci.org/browse/JENKINS-62339

Add a Symbol directive to allow the projectURLString to be specified in the options {} block of a pipeline script. The Symbol is named "githubProjectProperties" instead of "githubProjectProperty" to acknowledge that perhaps at some point a developer may want to set more than just the URL.

Projects that manage the Github project entry in their job definition may still do so manually, but pipeline and multibranch pipelines will now be able to manage the configuration through the Jenkinsfile.

Example:
```
options {
...
    githubProjectProperties(projectUrlStr: 'https://github.com/jenkinsci/github-plugin')
...
}
```

The only additional change was to switch from using another class's logger (e.g. the GitHubPushTrigger logger) to one specific for the GithubProjectProperty class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/233)
<!-- Reviewable:end -->
