### PR TITLE
Typo fix in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ void setBuildStatus(String message, String state) {
 setBuildStatus("Build complete", "SUCCESS");
 ```
 
-More complex examle (can be used with multiply scm sources in pipeline)
+More complex example (can be used with multiply scm sources in pipeline)
 
 ```groovy
 def getRepoURL() {


### PR DESCRIPTION
Small typo fix in README.md file 
More complex examle (can...... => More complex example (can....

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/234)
<!-- Reviewable:end -->
