### PR TITLE
Add Webhook register problem to Troubleshooting

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github/admin/GitHubHookRegisterProblemMonitor.java
+++ b/src/main/java/org/jenkinsci/plugins/github/admin/GitHubHookRegisterProblemMonitor.java
@@ -253,5 +253,11 @@ public class GitHubHookRegisterProblemMonitor extends AdministrativeMonitor impl
         public String getDisplayName() {
             return Messages.hooks_problem_administrative_monitor_displayname();
         }
+
+        // TODO: Override `getCategory` instead using `Category.TROUBLESHOOTING` when minimum core version is 2.226+,
+        // TODO: see https://github.com/jenkinsci/jenkins/commit/6de7e5fc7f6fb2e2e4cb342461788f97e3dfd8f6.
+        protected String getCategoryName() {
+            return "TROUBLESHOOTING";
+        }
     }
 }


### PR DESCRIPTION
Jenkins is adding categories to MagagementLink to group item.
This change adds the webhook problem item to the "Troubleshooting" category.

see https://github.com/jenkinsci/jenkins/pull/4546
see https://github.com/jenkinsci/script-security-plugin/pull/302