### PR TITLE
feat(updating reregisterallhooks method): only register parent, not all children

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubWebHook.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubWebHook.java
@@ -36,6 +36,7 @@ import static org.jenkinsci.plugins.github.extension.GHEventsSubscriber.processE
 import static org.jenkinsci.plugins.github.util.FluentIterableWrapper.from;
 import static org.jenkinsci.plugins.github.util.JobInfoHelpers.isAlive;
 import static org.jenkinsci.plugins.github.util.JobInfoHelpers.isBuildable;
+import static org.jenkinsci.plugins.github.util.JobInfoHelpers.isNotChild;
 import static org.jenkinsci.plugins.github.webhook.WebhookManager.forHookUrl;
 
 
@@ -104,6 +105,7 @@ public class GitHubWebHook implements UnprotectedRootAction {
         return from(getJenkinsInstance().getAllItems(Item.class))
                 .filter(isBuildable())
                 .filter(isAlive())
+                .filter(isNotChild())
                 .transform(reRegisterHookForJob())
                 .toList();
     }

--- a/src/main/java/com/cloudbees/jenkins/GitHubWebHook.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubWebHook.java
@@ -36,7 +36,7 @@ import static org.jenkinsci.plugins.github.extension.GHEventsSubscriber.processE
 import static org.jenkinsci.plugins.github.util.FluentIterableWrapper.from;
 import static org.jenkinsci.plugins.github.util.JobInfoHelpers.isAlive;
 import static org.jenkinsci.plugins.github.util.JobInfoHelpers.isBuildable;
-import static org.jenkinsci.plugins.github.util.JobInfoHelpers.isNotChild;
+import static org.jenkinsci.plugins.github.util.JobInfoHelpers.isNotSCMSourceOwner;
 import static org.jenkinsci.plugins.github.webhook.WebhookManager.forHookUrl;
 
 
@@ -105,7 +105,7 @@ public class GitHubWebHook implements UnprotectedRootAction {
         return from(getJenkinsInstance().getAllItems(Item.class))
                 .filter(isBuildable())
                 .filter(isAlive())
-                .filter(isNotChild())
+                .filter(isNotSCMSourceOwner())
                 .transform(reRegisterHookForJob())
                 .toList();
     }

--- a/src/main/java/org/jenkinsci/plugins/github/util/JobInfoHelpers.java
+++ b/src/main/java/org/jenkinsci/plugins/github/util/JobInfoHelpers.java
@@ -11,6 +11,7 @@ import hudson.model.Job;
 import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
 import jenkins.model.ParameterizedJobMixIn;
+import jenkins.scm.api.SCMSourceOwner;
 import org.jenkinsci.plugins.github.extension.GHEventsSubscriber;
 
 import javax.annotation.CheckForNull;
@@ -147,11 +148,10 @@ public final class JobInfoHelpers {
      *
      * @return predicate with true on apply if item is not a child of WorkflowMultiBranchProject
      */
-    public static <ITEM extends Item> Predicate<ITEM> isNotChild() {
+    public static <ITEM extends Item> Predicate<ITEM> isNotSCMSourceOwner() {
         return new Predicate<ITEM>() {
             public boolean apply(ITEM item) {
-                return !(item.getParent().getClass().getName().equals("org.jenkinsci.plugins.workflow.multibranch"
-                                                                 + ".WorkflowMultiBranchProject"));
+                return !(item.getParent() instanceof SCMSourceOwner);
             }
         };
     }

--- a/src/main/java/org/jenkinsci/plugins/github/util/JobInfoHelpers.java
+++ b/src/main/java/org/jenkinsci/plugins/github/util/JobInfoHelpers.java
@@ -141,5 +141,19 @@ public final class JobInfoHelpers {
             }
         };
     }
+
+    /**
+     * Can be useful to ignore child jobs on reregistering hooks
+     *
+     * @return predicate with true on apply if item is not a child of WorkflowMultiBranchProject
+     */
+    public static <ITEM extends Item> Predicate<ITEM> isNotChild() {
+        return new Predicate<ITEM>() {
+            public boolean apply(ITEM item) {
+                return !(item.getParent().getClass().getName().equals("org.jenkinsci.plugins.workflow.multibranch"
+                                                                 + ".WorkflowMultiBranchProject"));
+            }
+        };
+    }
 }
 


### PR DESCRIPTION
Instead of trying to register a webhook for each child job in a multibranch-pipeline project, only
register the base project.

With many multibranch pipelines and many prs/branches per project, the total number of calls to github (in my case github enterprise) can become very large and cause rate limiting/abuse rate limiting to be reached