### PR TITLE
[JENKINS-50154] Fix webhook payload signature generation when Unicode symbols are present in it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,11 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.9</version>    
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.7</version>
+        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/github/webhook/GHWebhookSignature.java
+++ b/src/main/java/org/jenkinsci/plugins/github/webhook/GHWebhookSignature.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.github.webhook;
 
 import hudson.util.Secret;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,7 +55,10 @@ public class GHWebhookSignature {
             final SecretKeySpec keySpec = new SecretKeySpec(secret.getPlainText().getBytes(UTF_8), HMAC_SHA1_ALGORITHM);
             final Mac mac = Mac.getInstance(HMAC_SHA1_ALGORITHM);
             mac.init(keySpec);
-            final byte[] rawHMACBytes = mac.doFinal(payload.getBytes(UTF_8));
+
+            final String unescapedPayload = StringEscapeUtils.unescapeJava(payload);
+            final String convertedUnicode = new String(unescapedPayload.getBytes("latin1"), UTF_8);
+            final byte[] rawHMACBytes = mac.doFinal(convertedUnicode.getBytes(UTF_8));
 
             return Hex.encodeHexString(rawHMACBytes);
         } catch (Exception e) {

--- a/src/main/java/org/jenkinsci/plugins/github/webhook/GHWebhookSignature.java
+++ b/src/main/java/org/jenkinsci/plugins/github/webhook/GHWebhookSignature.java
@@ -2,7 +2,7 @@ package org.jenkinsci.plugins.github.webhook;
 
 import hudson.util.Secret;
 import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/test/java/org/jenkinsci/plugins/github/webhook/GHWebhookSignatureTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/webhook/GHWebhookSignatureTest.java
@@ -1,4 +1,4 @@
-package org.jenkinsci.plugins.github.extension;
+package org.jenkinsci.plugins.github.webhook;
 
 import hudson.util.Secret;
 import org.junit.ClassRule;
@@ -14,7 +14,7 @@ import static org.junit.Assert.assertThat;
  *
  * @author martinmine
  */
-public class CryptoUtilTest {
+public class GHWebhookSignatureTest {
 
     private static final String SIGNATURE = "85d155c55ed286a300bd1cf124de08d87e914f3a";
     private static final String PAYLOAD = "foo";

--- a/src/test/java/org/jenkinsci/plugins/github/webhook/GHWebhookSignatureTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/webhook/GHWebhookSignatureTest.java
@@ -20,13 +20,17 @@ public class GHWebhookSignatureTest {
     private static final String PAYLOAD = "foo";
     private static final String SECRET = "bar";
 
+    // Taken from real example of Pull Request update webhook payload
+    private static final String UNICODE_PAYLOAD = "{\"description\":\"foo\\u00e2\\u0084\\u00a2\"}";
+    private static final String UNICODE_SIGNATURE = "10e3cb05d27049775aeca89d84d9e6123d5ab006";
+
     @ClassRule
     public static JenkinsRule jRule = new JenkinsRule();
 
     @Test
     public void shouldComputeSHA1Signature() throws Exception {
         assertThat("signature is valid", webhookSignature(
-                PAYLOAD, 
+                PAYLOAD,
                 Secret.fromString(SECRET)
         ).sha1(), equalTo(SIGNATURE));
     }
@@ -34,8 +38,16 @@ public class GHWebhookSignatureTest {
     @Test
     public void shouldMatchSignature() throws Exception {
         assertThat("signature should match", webhookSignature(
-                PAYLOAD, 
+                PAYLOAD,
                 Secret.fromString(SECRET)
         ).matches(SIGNATURE), equalTo(true));
+    }
+
+    @Test
+    public void shouldComputeSHA1SignatureWithUnicodePayload() throws Exception {
+        assertThat("signature is valid for unicode payload", webhookSignature(
+                UNICODE_PAYLOAD,
+                Secret.fromString(SECRET)
+        ).sha1(), equalTo(UNICODE_SIGNATURE));
     }
 }


### PR DESCRIPTION
This fixes a bug when plugin rejects webhook payload came from GitHub due to incorrect signature although secret token is configured correctly in Jenkins and GitHub repo/org settings.
It turned out that signature was generated incorrectly when Unicode characters were used in repo's description (in our case it was the ™ character). 

I have a concern of using already deprecated method in new code, but the alternative is to add new dependency to pom.xml (apache-commons.text)