### PR TITLE
JENKINS-64536 Remove tabular form markup on system configuration page

### DIFF
--- a/src/main/resources/lib/github/blockWrapper.jelly
+++ b/src/main/resources/lib/github/blockWrapper.jelly
@@ -1,0 +1,16 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define">
+    <!-- TODO remove and switch to div after baseline is 2.264 or newer -->
+    <j:choose>
+        <j:when test="${divBasedFormLayout}">
+            <div>
+                <d:invokeBody/>
+            </div>
+        </j:when>
+        <j:otherwise>
+            <table style="width:100%">
+                <d:invokeBody/>
+            </table>
+        </j:otherwise>
+    </j:choose>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/config.groovy
@@ -4,6 +4,7 @@ import com.cloudbees.jenkins.GitHubPushTrigger
 import lib.FormTagLib
 
 def f = namespace(FormTagLib);
+def g = namespace("/lib/matrixauth")
 
 f.section(title: descriptor.displayName) {
     f.entry(title: _("GitHub Servers"),
@@ -24,7 +25,7 @@ f.section(title: descriptor.displayName) {
         
         if (GitHubPushTrigger.ALLOW_HOOKURL_OVERRIDE) {
             f.entry(title: _("Override Hook URL")) {
-                table(width: "100%", style: "margin-left: 7px;") {
+                g.blockWrapper {
                     f.optionalBlock(title: _("Specify another hook URL for GitHub configuration"),
                             inline: true,
                             checked: instance.isOverrideHookUrl()) {

--- a/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/github/config/GitHubPluginConfig/config.groovy
@@ -4,7 +4,7 @@ import com.cloudbees.jenkins.GitHubPushTrigger
 import lib.FormTagLib
 
 def f = namespace(FormTagLib);
-def g = namespace("/lib/matrixauth")
+def g = namespace("/lib/github")
 
 f.section(title: descriptor.displayName) {
     f.entry(title: _("GitHub Servers"),


### PR DESCRIPTION
Pretty similar fix to https://github.com/jenkinsci/matrix-auth-plugin/commit/31b3bbc14062974f240a26cf88ae04e6c9415571

See https://www.jenkins.io/doc/developer/views/table-to-div-migration/ and https://www.jenkins.io/blog/2020/11/10/major-changes-in-weekly-releases/

cc @KostyaSha 

requires https://github.com/jenkinsci/github-plugin/pull/243