### PR TITLE
Remove usages of `com.google.common.base.Objects#firstNonNull`

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubCommitNotifier.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubCommitNotifier.java
@@ -37,7 +37,6 @@ import java.io.IOException;
 import java.util.Collections;
 
 import static com.cloudbees.jenkins.Messages.GitHubCommitNotifier_DisplayName;
-import static com.google.common.base.Objects.firstNonNull;
 import static hudson.model.Result.FAILURE;
 import static hudson.model.Result.SUCCESS;
 import static hudson.model.Result.UNSTABLE;
@@ -125,7 +124,7 @@ public class GitHubCommitNotifier extends Notifier implements SimpleBuildStep {
         setter.setContextSource(new DefaultCommitContextSource());
 
 
-        String content = firstNonNull(statusMessage, DEFAULT_MESSAGE).getContent();
+        String content = (statusMessage != null ? statusMessage : DEFAULT_MESSAGE).getContent();
 
         if (isNotBlank(content)) {
             setter.setStatusResultSource(new ConditionalStatusResultSource(

--- a/src/main/java/com/cloudbees/jenkins/GitHubSetCommitStatusBuilder.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubSetCommitStatusBuilder.java
@@ -27,7 +27,6 @@ import org.kohsuke.stapler.DataBoundSetter;
 import java.io.IOException;
 import java.util.Collections;
 
-import static com.google.common.base.Objects.firstNonNull;
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 import static org.jenkinsci.plugins.github.status.sources.misc.AnyBuildResult.onAnyResult;
 
@@ -89,7 +88,7 @@ public class GitHubSetCommitStatusBuilder extends Builder implements SimpleBuild
                 Collections.<ConditionalResult>singletonList(
                         onAnyResult(
                                 GHCommitState.PENDING,
-                                defaultIfEmpty(firstNonNull(statusMessage, DEFAULT_MESSAGE).getContent(),
+                                defaultIfEmpty((statusMessage != null ? statusMessage : DEFAULT_MESSAGE).getContent(),
                                         Messages.CommitNotifier_Pending(build.getDisplayName()))
                         )
                 )));


### PR DESCRIPTION
`com.google.common.base.Objects#firstNonNull` has been removed in recent versions of Guava, so consuming this API is a liability. This PR replaces usages of `com.google.common.base.Objects#firstNonNull` with native Java functionality to allow this plugin to be used seamlessly with any version of Guava in the future.