### PR TITLE
Fix linking of "Closed" issues

### DIFF
--- a/src/main/java/com/coravy/hudson/plugins/github/GithubLinkAnnotator.java
+++ b/src/main/java/com/coravy/hudson/plugins/github/GithubLinkAnnotator.java
@@ -77,5 +77,5 @@ public class GithubLinkAnnotator extends ChangeLogAnnotator {
 
     private static final LinkMarkup[] MARKUPS = new LinkMarkup[]{new LinkMarkup(
             "(?:C|c)lose(?:s?)\\s(?<!\\:)(?:#)NUM", // "Closes #123"
-            "issues/$1/find")};
+            "issues/$1")};
 }

--- a/src/test/java/com/coravy/hudson/plugins/github/GithubLinkAnnotatorTest.java
+++ b/src/test/java/com/coravy/hudson/plugins/github/GithubLinkAnnotatorTest.java
@@ -43,7 +43,7 @@ public class GithubLinkAnnotatorTest {
     private static Object[] genActualAndExpected(String keyword) {
         int issueNumber = RANDOM.nextInt(1000000);
         final String innerText = keyword + " #" + issueNumber;
-        final String startHREF = "<a href='" + GITHUB_URL + "/issues/" + issueNumber + "/find'>";
+        final String startHREF = "<a href='" + GITHUB_URL + "/issues/" + issueNumber + "'>";
         final String endHREF = "</a>";
         final String annotatedText = startHREF + innerText + endHREF;
         return new Object[]{


### PR DESCRIPTION
GitHub does no longer utilize the `/find` endpoint for linking issues. Keeping it up results in GitHub responding with a 404.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
