### PR TITLE
The plugin would fail to start for the MigratorTests

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/github/migration/MigratorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/migration/MigratorTest.java
@@ -82,7 +82,7 @@ public class MigratorTest {
     @Test
     @LocalData
     public void shouldLoadDataAfterStart() throws Exception {
-        assertThat("should load 3 configs", GitHubPlugin.configuration().getConfigs(), hasSize(2));
+        assertThat("should load 2 configs", GitHubPlugin.configuration().getConfigs(), hasSize(2));
         assertThat("migrate custom url", GitHubPlugin.configuration().getConfigs(), hasItems(
                 withApiUrl(is(CUSTOM_GH_URL)),
                 withApiUrl(is(GITHUB_URL))

--- a/src/test/resources/org/jenkinsci/plugins/github/migration/MigratorTest/shouldLoadDataAfterStart/config.xml
+++ b/src/test/resources/org/jenkinsci/plugins/github/migration/MigratorTest/shouldLoadDataAfterStart/config.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <hudson>
     <disabledAdministrativeMonitors/>
-    <version>1.554.1</version>
+    <version>1.565.11</version>
     <numExecutors>2</numExecutors>
     <mode>NORMAL</mode>
     <useSecurity>true</useSecurity>


### PR DESCRIPTION
As the migration test used an old version for Jenkins core before
`matrix-plugin` was detached, when Jenkins was started with `JenkinsRule`
Jenkins would install the detached version of the plugin which was older
than the version of the plugin that should come from the bom.

This caused the plugin to fail to be loaded correctly so it would never
start and not initialize the xstream aliases.

can be easily reproduced with `mvn test -DreuseForks=false` which is the
latest in the [plugin pom 4.31+](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.31) to ensure build stability.

```
=== Starting shouldLoadDataAfterStart(org.jenkinsci.plugins.github.migration.MigratorTest)
   0.077 [id=22]        INFO    o.jvnet.hudson.test.WarExploder#explode: Exploding c:\sources\.m2\repository\org\jenkins-ci\main\jenkins-war\2.222.4\jenkins-war-2.222.4.war into C:\workarea\source\github\jenkinsci\github-plugin\target\jenkins-for-test
   2.784 [id=22]        INFO    o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:62180/jenkins/
Loading $JENKINS_HOME from C:\workarea\source\github\jenkinsci\github-plugin\target\test-classes\org\jenkinsci\plugins\github\migration\MigratorTest\shouldLoadDataAfterStart
   4.470 [id=38]        INFO    jenkins.InitReactorRunner$1#onAttained: Started initialization
   4.629 [id=36]        INFO    hudson.PluginManager#loadDetachedPlugins: Upgrading Jenkins. The last running version was 1.554.1. This Jenkins is version 2.222.4.
   4.707 [id=36]        INFO    hudson.PluginManager#loadDetachedPlugins: Upgraded Jenkins from version 1.554.1 to version 2.222.4. Loaded detached plugins (and dependencies): [junit.hpi, command-launcher.hpi, bouncycastle-api.hpi, jdk-tool.hpi, matrix-project.hpi]
   6.748 [id=46]        INFO    jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   6.800 [id=41]        INFO    j.b.a.SecurityProviderInitializer#addSecurityProvider: Initializing Bouncy Castle security provider.
   6.988 [id=41]        INFO    j.b.a.SecurityProviderInitializer#addSecurityProvider: Bouncy Castle security provider initialized.
   6.992 [id=52]        SEVERE  jenkins.InitReactorRunner$1#onTaskFailed: Failed Loading plugin Jenkins Git plugin v4.5.0 (git)
java.io.IOException: Failed to load: Jenkins Git plugin (4.5.0)
 - Update required: Matrix Project Plugin (1.14) to be updated to 1.18 or higher
        at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:933)
        at hudson.PluginManager$2$1$1.run(PluginManager.java:546)
        at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
        at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:296)
        at jenkins.model.Jenkins$5.runTask(Jenkins.java:1133)
        at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:214)
        at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
        at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:59)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
   6.994 [id=52]        SEVERE  jenkins.InitReactorRunner$1#onTaskFailed: Failed Loading plugin GitHub plugin v1.34.2-SNAPSHOT (private-5747884d-jnord) (github)
java.io.IOException: Failed to load: GitHub plugin (1.34.2-SNAPSHOT (private-5747884d-jnord))
 - Failed to load: Jenkins Git plugin (4.5.0)
        at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:933)
        at hudson.PluginManager$2$1$1.run(PluginManager.java:546)
        at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
        at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:296)
        at jenkins.model.Jenkins$5.runTask(Jenkins.java:1133)
        at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:214)
        at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
        at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:59)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```

test failure was

```
java.lang.AssertionError:
should load 3 configs
Expected: a collection with size <2>
     but: collection size was <0>
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.jenkinsci.plugins.github.migration.MigratorTest.shouldLoadDataAfterStart(MigratorTest.java:85)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```

```
0.008 [id=122]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on <http://localhost:43017/jenkins/>
Loading $JENKINS_HOME from /jenkins/workspace/builders_URR-pr-builder_PR-5140/output-github/work/github/target/test-classes/org/jenkinsci/plugins/github/migration/MigratorTest/shouldLoadDataAfterStart
   0.158 [id=135]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   0.159 [id=137]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   0.275 [id=135]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   0.275 [id=136]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   0.275 [id=134]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   0.277 [id=137]	INFO	jenkins.model.Jenkins#setBuildsAndWorkspacesDir: Using non default workspaces directories: ${JENKINS_HOME}/workspace/${ITEM_FULLNAME}.
   0.281 [id=136]	WARNING	hudson.model.Descriptor#load: Failed to load /jenkins/workspace/builders_URR-pr-builder_PR-5140/output-github/work/github/target/tmp/j h2547530903229256595/github-plugin-configuration.xml
com.thoughtworks.xstream.mapper.CannotResolveClassException: github-plugin-configuration
	at com.thoughtworks.xstream.mapper.DefaultMapper.realClass(DefaultMapper.java:81)
	at com.thoughtworks.xstream.mapper.MapperWrapper.realClass(MapperWrapper.java:125)
	at com.thoughtworks.xstream.mapper.DynamicProxyMapper.realClass(DynamicProxyMapper.java:55)
	at com.thoughtworks.xstream.mapper.MapperWrapper.realClass(MapperWrapper.java:125)
	at com.thoughtworks.xstream.mapper.PackageAliasingMapper.realClass(PackageAliasingMapper.java:88)
	at com.thoughtworks.xstream.mapper.MapperWrapper.realClass(MapperWrapper.java:125)
	at com.thoughtworks.xstream.mapper.ClassAliasingMapper.realClass(ClassAliasingMapper.java:79)
	at com.thoughtworks.xstream.mapper.MapperWrapper.realClass(MapperWrapper.java:125)
	at com.thoughtworks.xstream.mapper.ArrayMapper.realClass(ArrayMapper.java:74)
	at com.thoughtworks.xstream.mapper.MapperWrapper.realClass(MapperWrapper.java:125)
	at com.thoughtworks.xstream.mapper.SecurityMapper.realClass(SecurityMapper.java:71)
	at com.thoughtworks.xstream.mapper.MapperWrapper.realClass(MapperWrapper.java:125)
	at hudson.util.XStream2$CompatibilityMapper.realClass(XStream2.java:388)
	at hudson.util.xstream.MapperDelegate.realClass(MapperDelegate.java:45)
	at com.thoughtworks.xstream.mapper.MapperWrapper.realClass(MapperWrapper.java:125)
	at com.thoughtworks.xstream.mapper.CachingMapper.realClass(CachingMapper.java:47)
	at com.thoughtworks.xstream.core.util.HierarchicalStreams.readClassType(HierarchicalStreams.java:29)
	at com.thoughtworks.xstream.core.TreeUnmarshaller.start(TreeUnmarshaller.java:133)
	at com.thoughtworks.xstream.core.AbstractTreeMarshallingStrategy.unmarshal(AbstractTreeMarshallingStrategy.java:32)
	at com.thoughtworks.xstream.XStream.unmarshal(XStream.java:1391)
	at hudson.util.XStream2.unmarshal(XStream2.java:171)
	at hudson.util.XStream2.unmarshal(XStream2.java:142)
	at com.thoughtworks.xstream.XStream.unmarshal(XStream.java:1376)
	at hudson.XmlFile.unmarshal(XmlFile.java:180)
Caused: java.io.IOException: Unable to read /jenkins/workspace/builders_URR-pr-builder_PR-5140/output-github/work/github/target/tmp/j h2547530903229256595/github-plugin-configuration.xml
	at hudson.XmlFile.unmarshal(XmlFile.java:183)
	at hudson.XmlFile.unmarshal(XmlFile.java:163)
	at hudson.model.Descriptor.load(Descriptor.java:920)
	at org.jenkinsci.plugins.github.config.GitHubPluginConfig.<init>(GitHubPluginConfig.java:86)
	at org.jenkinsci.plugins.github.config.GitHubPluginConfig$$FastClassByGuice$$cfc1c5a3.newInstance(<generated>)
	at com.google.inject.internal.cglib.reflect.$FastConstructor.newInstance(FastConstructor.java:40)
	at com.google.inject.internal.DefaultConstructionProxyFactory$1.newInstance(DefaultConstructionProxyFactory.java:61)
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:105)
	at com.google.inject.internal.ConstructorInjector.access$000(ConstructorInjector.java:32)
	at com.google.inject.internal.ConstructorInjector$1.call(ConstructorInjector.java:89)
	at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:115)
	at hudson.ExtensionFinder$GuiceFinder$SezpozModule.onProvision(ExtensionFinder.java:568)
	at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:126)
	at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:68)
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:87)
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:267)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
	at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1103)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:145)
	at hudson.ExtensionFinder$GuiceFinder$FaultTolerantScope$1.get(ExtensionFinder.java:441)
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:41)
	at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:1016)
	at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1092)
	at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:1012)
	at hudson.ExtensionFinder$GuiceFinder._find(ExtensionFinder.java:401)
	at hudson.ExtensionFinder$GuiceFinder.find(ExtensionFinder.java:392)
	at hudson.ClassicPluginStrategy.findComponents(ClassicPluginStrategy.java:349)
	at hudson.ExtensionList.load(ExtensionList.java:382)
	at hudson.ExtensionList.ensureLoaded(ExtensionList.java:318)
	at hudson.ExtensionList.getComponents(ExtensionList.java:182)
	at hudson.DescriptorExtensionList.load(DescriptorExtensionList.java:212)
	at hudson.ExtensionList.ensureLoaded(ExtensionList.java:318)
	at hudson.ExtensionList.iterator(ExtensionList.java:170)
	at hudson.ExtensionList.get(ExtensionList.java:147)
	at com.cloudbees.jenkins.GitHubPushTrigger$DescriptorImpl.get(GitHubPushTrigger.java:409)
	at org.jenkinsci.plugins.github.migration.Migrator.migrate(Migrator.java:40)
	at org.jenkinsci.plugins.github.GitHubPlugin.runMigrator(GitHubPlugin.java:39)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:104)
	at hudson.init.TaskMethodFinder$TaskImpl.run(TaskMethodFinder.java:180)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:296)
	at jenkins.model.Jenkins$5.runTask(Jenkins.java:1158)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:214)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
   1.464 [id=135]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   1.473 [id=135]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   1.474 [id=135]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   1.474 [id=137]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   1.474 [id=136]	INFO	hudson.model.AllView#migrateLegacyPrimaryAllViewLocalizedName: JENKINS-38606 detected for AllView in hudson.model.Hudson@20fbff3e; renaming view from All to all
   1.478 [id=136]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   1.493 [id=122]	INFO	jenkins.model.Jenkins#cleanUp: Stopping Jenkins
   1.547 [id=122]	INFO	jenkins.model.Jenkins#cleanUp: Jenkins stopped
```

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

@KostyaSha 