### PR TITLE
Fix to enable authentication with used HTTP proxy ( JENKINS-67806  )

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,11 @@
             <version>3.11</version>
         </dependency>
         <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>okhttp-api</artifactId>
+            <version>4.9.2-20211102</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
             <version>1.114.2</version>

--- a/src/main/java/org/jenkinsci/plugins/github/internal/GitHubLoginFunction.java
+++ b/src/main/java/org/jenkinsci/plugins/github/internal/GitHubLoginFunction.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.github.internal;
 
 import com.cloudbees.jenkins.GitHubWebHook;
+import io.jenkins.plugins.okhttp.api.JenkinsOkHttpClient;
 import okhttp3.Cache;
 import okhttp3.OkHttpClient;
 import jenkins.model.Jenkins;
@@ -44,7 +45,7 @@ import static org.jenkinsci.plugins.github.internal.GitHubClientCacheOps.toCache
 @Restricted(NoExternalUse.class)
 public class GitHubLoginFunction extends NullSafeFunction<GitHubServerConfig, GitHub> {
 
-    private static final OkHttpClient BASECLIENT = new OkHttpClient();
+    private static final OkHttpClient BASECLIENT = JenkinsOkHttpClient.newClientBuilder(new OkHttpClient()).build();
     private static final Logger LOGGER = LoggerFactory.getLogger(GitHubLoginFunction.class);
 
     /**
@@ -107,7 +108,7 @@ public class GitHubLoginFunction extends NullSafeFunction<GitHubServerConfig, Gi
      */
     private OkHttpConnector connector(GitHubServerConfig config) {
         OkHttpClient.Builder builder = BASECLIENT.newBuilder()
-            .proxy(getProxy(defaultIfBlank(config.getApiUrl(), GITHUB_URL)));
+            .proxy(getProxy(defaultIfBlank(config.getApiUrl(), GITHUB_URL)))
 
 
         if (config.getClientCacheSize() > 0) {

--- a/src/main/java/org/jenkinsci/plugins/github/internal/GitHubLoginFunction.java
+++ b/src/main/java/org/jenkinsci/plugins/github/internal/GitHubLoginFunction.java
@@ -108,7 +108,7 @@ public class GitHubLoginFunction extends NullSafeFunction<GitHubServerConfig, Gi
      */
     private OkHttpConnector connector(GitHubServerConfig config) {
         OkHttpClient.Builder builder = BASECLIENT.newBuilder()
-            .proxy(getProxy(defaultIfBlank(config.getApiUrl(), GITHUB_URL)))
+            .proxy(getProxy(defaultIfBlank(config.getApiUrl(), GITHUB_URL)));
 
 
         if (config.getClientCacheSize() > 0) {


### PR DESCRIPTION
Currently the Github plugin can not reach the Github server if the proxy used
by Jenkins requires authentication. Reason for that lies in the missing
configuration of proxy authenticator for the Github plugin.

This commit should resolve that issue by introducing a new HTTP client which is
preconfigured to handle the usage of Jenkins proxy configurations

This commit should resolve issue JENKINS-67806

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
