### PR TITLE
fix: don't trigger poll unless target ref matches

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubBranch.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubBranch.java
@@ -1,0 +1,59 @@
+package com.cloudbees.jenkins;
+
+import hudson.plugins.git.BranchSpec;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Identifies a GitHub branch and hides the SCM branch from its clients.
+ */
+public class GitHubBranch {
+
+    private static final String GITHUB_BRANCH_PREFIX = "refs/heads";
+    private static final int GITHUB_BRANCH_PREFIX_LENGTH = 10;
+
+    private final BranchSpec branch;
+
+    private GitHubBranch(final BranchSpec branch) {
+        this.branch = branch;
+    }
+
+    public boolean matches(GitHubRepositoryName repository, String ref) {
+        // ref (github) -> refs/heads/master
+        // branch (git SCM) -> REPO/remote/branch
+        // matching the meaningful part of the github branch name with
+        // the configured SCM branch expression
+        if (ref != null && !ref.equals("")) {
+            String branchExpression = "*";
+            if (repository != null && repository.repositoryName != null) {
+                branchExpression = repository.repositoryName;
+            }
+            if (ref.startsWith(GITHUB_BRANCH_PREFIX)) {
+                branchExpression += ref.substring(GITHUB_BRANCH_PREFIX_LENGTH);
+            } else {
+                branchExpression += "/" + ref;
+            }
+            LOGGER.log(Level.FINE, "Does SCM branch " + branch.getName()
+                    + " match GitHub branch " + branchExpression + "?");
+            return branch.matches(branchExpression);
+        }
+        return false;
+    }
+
+    public static GitHubBranch create(BranchSpec branch) {
+        if (isValidGitHubBranch(branch)) {
+            return new GitHubBranch(branch);
+        } else {
+            return null;
+        }
+    }
+
+    // TODO: implement logic to validate git SCM branches.
+    private static boolean isValidGitHubBranch(BranchSpec branch) {
+        return true;
+    }
+
+    private static final Logger LOGGER = Logger.getLogger(GitHubBranch.class
+            .getName());
+}

--- a/src/main/java/com/cloudbees/jenkins/GitHubPushCause.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubPushCause.java
@@ -19,30 +19,37 @@ public class GitHubPushCause extends SCMTriggerCause {
      * The name of the user who pushed to GitHub.
      */
     private String pushedBy;
+    /**
+     * The target ref of the triggering GitHub push.
+     */
+    private String ref;
 
-    public GitHubPushCause(String pusher) {
-        this("", pusher);
+    public GitHubPushCause(String pusher, String ref) {
+        this("", pusher, ref);
     }
 
-    public GitHubPushCause(String pollingLog, String pusher) {
+    public GitHubPushCause(String pollingLog, String pusher, String ref) {
         super(pollingLog);
-        pushedBy = pusher;
+        this.pushedBy = pusher;
+        this.ref = ref;
     }
 
-    public GitHubPushCause(File pollingLog, String pusher) throws IOException {
+    public GitHubPushCause(File pollingLog, String pusher, String ref) throws IOException {
         super(pollingLog);
-        pushedBy = pusher;
+        this.pushedBy = pusher;
+        this.ref = ref;
     }
 
     @Override
     public String getShortDescription() {
-        return format("Started by GitHub push by %s", trimToEmpty(pushedBy));
+        return format("Started by GitHub push to %s by %s", trimToEmpty(ref), trimToEmpty(pushedBy));
     }
 
     @Override
     public boolean equals(Object o) {
         return o instanceof GitHubPushCause
                 && Objects.equals(this.pushedBy, ((GitHubPushCause) o).pushedBy)
+                && Objects.equals(this.ref, ((GitHubPushCause) o).ref)
                 && super.equals(o);
     }
 
@@ -50,7 +57,7 @@ public class GitHubPushCause extends SCMTriggerCause {
     public int hashCode() {
         int hash = super.hashCode();
         hash = 89 * hash + Objects.hash(this.pushedBy);
+        hash = 89 * hash + Objects.hash(this.ref);
         return hash;
     }
 }
-

--- a/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
@@ -195,6 +195,14 @@ public class GitHubPushTrigger extends Trigger<Job<?, ?>> implements GitHubTrigg
         return Collections.emptySet();
     }
 
+    /**
+     * @deprecated
+     *      Use {@link GitHubRepositoryNameContributor#parseAssociatedBranches(AbstractProject)}
+     */
+    public Set<GitHubBranch> getGitHubBranches() {
+        return Collections.emptySet();
+    }
+
     @Override
     public void start(Job<?, ?> project, boolean newInstance) {
         super.start(project, newInstance);

--- a/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
@@ -84,10 +84,11 @@ public class GitHubPushTrigger extends Trigger<Job<?, ?>> implements GitHubTrigg
     /**
      * Called when a POST is made.
      */
-    public void onPost(String triggeredByUser) {
+    public void onPost(String triggeredByUser, String triggeredByRef) {
         onPost(GitHubTriggerEvent.create()
                 .withOrigin(SCMEvent.originOf(Stapler.getCurrentRequest2()))
                 .withTriggeredByUser(triggeredByUser)
+                .withTriggeredByRef(triggeredByRef)
                 .build()
         );
     }
@@ -103,6 +104,7 @@ public class GitHubPushTrigger extends Trigger<Job<?, ?>> implements GitHubTrigg
         Job<?, ?> currentJob = notNull(job, "Job can't be null");
 
         final String pushBy = event.getTriggeredByUser();
+        final String ref = event.getTriggeredByRef();
         DescriptorImpl d = getDescriptor();
         d.checkThreadPoolSizeAndUpdateIfNecessary();
         d.queue.execute(new Runnable() {
@@ -151,10 +153,10 @@ public class GitHubPushTrigger extends Trigger<Job<?, ?>> implements GitHubTrigg
                 if (runPolling()) {
                     GitHubPushCause cause;
                     try {
-                        cause = new GitHubPushCause(getLogFileForJob(currentJob), pushBy);
+                        cause = new GitHubPushCause(getLogFileForJob(currentJob), pushBy, ref);
                     } catch (IOException e) {
                         LOGGER.warn("Failed to parse the polling log", e);
-                        cause = new GitHubPushCause(pushBy);
+                        cause = new GitHubPushCause(pushBy, ref);
                     }
 
                     if (asParameterizedJobMixIn(currentJob).scheduleBuild(cause)) {

--- a/src/main/java/com/cloudbees/jenkins/GitHubRepositoryNameContributor.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubRepositoryNameContributor.java
@@ -112,7 +112,7 @@ public abstract class GitHubRepositoryNameContributor implements ExtensionPoint 
                 getClass(),
                 "parseAssociatedBranches",
                 AbstractProject.class,
-            Collection.class
+                Collection.class
         )) {
             // if this impl is legacy, it cannot contribute to non-projects, so not an error
             if (item instanceof AbstractProject) {
@@ -149,6 +149,22 @@ public abstract class GitHubRepositoryNameContributor implements ExtensionPoint 
             c.parseAssociatedNames(item, names);
         }
         return names;
+    }
+
+    /**
+     * @deprecated Use {@link #parseAssociatedBranches(Job)}
+     */
+    @Deprecated
+    public static Collection<GitHubBranch> parseAssociatedBranches(AbstractProject<?, ?> job) {
+        return parseAssociatedBranches((Item) job);
+    }
+
+    /**
+     * @deprecated Use {@link #parseAssociatedBranches(Item)}
+     */
+    @Deprecated
+    public static Collection<GitHubBranch> parseAssociatedBranches(Job<?, ?> job) {
+        return parseAssociatedBranches((Item) job);
     }
 
     public static Collection<GitHubBranch> parseAssociatedBranches(Item item) {

--- a/src/main/java/com/cloudbees/jenkins/GitHubTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubTrigger.java
@@ -41,8 +41,25 @@ public interface GitHubTrigger {
     Set<GitHubRepositoryName> getGitHubRepositories();
 
     /**
+     * Obtains the list of the branches that this trigger is looking at.
+     *
+     * If the implementation of this class maintain its own list of GitHub branches, it should
+     * continue to implement this method for backward compatibility, and it gets picked up by
+     * {@link GitHubRepositoryNameContributor#parseAssociatedBranches(AbstractProject)}.
+     *
+     * <p>
+     * Alternatively, if the implementation doesn't worry about the backward compatibility, it can
+     * implement this method to return an empty collection, then just implement {@link GitHubRepositoryNameContributor}.
+     *
+     * @deprecated
+     *      Call {@link GitHubRepositoryNameContributor#parseAssociatedBranches(AbstractProject)} instead.
+     */
+    Set<GitHubBranch> getGitHubBranches();
+
+    /**
      * Contributes {@link GitHubRepositoryName} from {@link GitHubTrigger#getGitHubRepositories()}
-     * for backward compatibility
+     * and {@link GitHubBranch} from {@link GitHubTrigger#getGitHubBranches()} for
+     * backward compatibility.
      */
     @Extension
     class GitHubRepositoryNameContributorImpl extends GitHubRepositoryNameContributor {
@@ -53,6 +70,16 @@ public interface GitHubTrigger {
                 // TODO use standard method in 1.621+
                 for (GitHubTrigger ght : Util.filter(p.getTriggers().values(), GitHubTrigger.class)) {
                     result.addAll(ght.getGitHubRepositories());
+                }
+            }
+        }
+
+        @Override
+        public void parseAssociatedBranches(Item item, Collection<GitHubBranch> result) {
+            if (item instanceof ParameterizedJobMixIn.ParameterizedJob) {
+                ParameterizedJobMixIn.ParameterizedJob p = (ParameterizedJobMixIn.ParameterizedJob) item;
+                for (GitHubTrigger ght : Util.filter(p.getTriggers().values(), GitHubTrigger.class)) {
+                    result.addAll(ght.getGitHubBranches());
                 }
             }
         }

--- a/src/main/java/com/cloudbees/jenkins/GitHubTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubTrigger.java
@@ -23,7 +23,7 @@ public interface GitHubTrigger {
     void onPost();
 
     // TODO: document me
-    void onPost(String triggeredByUser);
+    void onPost(String triggeredByUser, String triggeredByRef);
 
     /**
      * Obtains the list of the repositories that this trigger is looking at.

--- a/src/main/java/com/cloudbees/jenkins/GitHubTriggerEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubTriggerEvent.java
@@ -22,11 +22,16 @@ public class GitHubTriggerEvent {
      * The user that the event was provided by.
      */
     private final String triggeredByUser;
+    /**
+     * The target ref that the push event was for.
+     */
+    private final String triggeredByRef;
 
-    private GitHubTriggerEvent(long timestamp, String origin, String triggeredByUser) {
+    private GitHubTriggerEvent(long timestamp, String origin, String triggeredByUser, String triggeredByRef) {
         this.timestamp = timestamp;
         this.origin = origin;
         this.triggeredByUser = triggeredByUser;
+        this.triggeredByRef = triggeredByRef;
     }
 
     public static Builder create() {
@@ -43,6 +48,10 @@ public class GitHubTriggerEvent {
 
     public String getTriggeredByUser() {
         return triggeredByUser;
+    }
+
+    public String getTriggeredByRef() {
+        return triggeredByRef;
     }
 
     @Override
@@ -62,7 +71,10 @@ public class GitHubTriggerEvent {
         if (origin != null ? !origin.equals(that.origin) : that.origin != null) {
             return false;
         }
-        return triggeredByUser != null ? triggeredByUser.equals(that.triggeredByUser) : that.triggeredByUser == null;
+        if (triggeredByUser != null ? !triggeredByUser.equals(that.triggeredByUser) : that.triggeredByUser != null) {
+            return false;
+        }
+        return triggeredByRef != null ? triggeredByRef.equals(that.triggeredByRef) : that.triggeredByRef == null;
     }
 
     @Override
@@ -70,6 +82,7 @@ public class GitHubTriggerEvent {
         int result = (int) (timestamp ^ (timestamp >>> 32));
         result = 31 * result + (origin != null ? origin.hashCode() : 0);
         result = 31 * result + (triggeredByUser != null ? triggeredByUser.hashCode() : 0);
+        result = 31 * result + (triggeredByRef != null ? triggeredByRef.hashCode() : 0);
         return result;
     }
 
@@ -79,6 +92,7 @@ public class GitHubTriggerEvent {
                 + "timestamp=" + timestamp
                 + ", origin='" + origin + '\''
                 + ", triggeredByUser='" + triggeredByUser + '\''
+                + ", triggeredByRef='" + triggeredByRef + '\''
                 + '}';
     }
 
@@ -89,6 +103,7 @@ public class GitHubTriggerEvent {
         private long timestamp;
         private String origin;
         private String triggeredByUser;
+        private String triggeredByRef;
 
         private Builder() {
             timestamp = System.currentTimeMillis();
@@ -109,8 +124,13 @@ public class GitHubTriggerEvent {
             return this;
         }
 
+        public Builder withTriggeredByRef(String triggeredByRef) {
+            this.triggeredByRef = triggeredByRef;
+            return this;
+        }
+
         public GitHubTriggerEvent build() {
-            return new GitHubTriggerEvent(timestamp, origin, triggeredByUser);
+            return new GitHubTriggerEvent(timestamp, origin, triggeredByUser, triggeredByRef);
         }
 
         @Override
@@ -119,6 +139,7 @@ public class GitHubTriggerEvent {
                     + "timestamp=" + timestamp
                     + ", origin='" + origin + '\''
                     + ", triggeredByUser='" + triggeredByUser + '\''
+                    + ", triggeredByRef='" + triggeredByRef + '\''
                     + '}';
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/github/migration/Migrator.java
+++ b/src/main/java/org/jenkinsci/plugins/github/migration/Migrator.java
@@ -38,6 +38,9 @@ public class Migrator {
     public void migrate() throws IOException {
         LOGGER.debug("Check if GitHub Plugin needs config migration");
         GitHubPushTrigger.DescriptorImpl descriptor = GitHubPushTrigger.DescriptorImpl.get();
+        if (descriptor == null) {
+            return;
+        }
         descriptor.load();
 
         if (isNotEmpty(descriptor.getCredentials())) {

--- a/src/main/java/org/jenkinsci/plugins/github/util/misc/NullSafeFunction.java
+++ b/src/main/java/org/jenkinsci/plugins/github/util/misc/NullSafeFunction.java
@@ -14,6 +14,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public abstract class NullSafeFunction<F, T> implements Function<F, T> {
 
     @Override
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+        value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+        justification = "https://github.com/spotbugs/spotbugs/issues/616"
+    )
     public T apply(F input) {
         return applyNullSafe(checkNotNull(input, "This function does not allow using null as argument"));
     }

--- a/src/main/java/org/jenkinsci/plugins/github/util/misc/NullSafePredicate.java
+++ b/src/main/java/org/jenkinsci/plugins/github/util/misc/NullSafePredicate.java
@@ -15,6 +15,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public abstract class NullSafePredicate<T> implements Predicate<T> {
 
     @Override
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+        value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+        justification = "https://github.com/spotbugs/spotbugs/issues/616"
+    )
     public boolean apply(T input) {
         return applyNullSafe(checkNotNull(input, "Argument for this predicate can't be null"));
     }

--- a/src/main/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventSubscriber.java
+++ b/src/main/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventSubscriber.java
@@ -134,7 +134,7 @@ public class DefaultPushGHEventSubscriber extends GHEventsSubscriber {
                                     }
                                 }
                                 if (!foundBranch) {
-                                    LOGGER.debug("Skipped {} because it doesn't have a matching branch specifier.",
+                                    LOGGER.info("Skipped {} because it doesn't have a matching branch specifier.",
                                         job.getFullDisplayName());
                                     continue;
                                 }

--- a/src/test/java/com/cloudbees/jenkins/GitHubBranchTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GitHubBranchTest.java
@@ -1,0 +1,42 @@
+package com.cloudbees.jenkins;
+
+import hudson.plugins.git.BranchSpec;
+import org.junit.Assert;
+
+import org.junit.Test;
+
+public class GitHubBranchTest {
+
+    @Test
+    public void testBranchMatch() throws Exception, InterruptedException {
+        GitHubRepositoryName repo = GitHubRepositoryName.create("github-repo");
+
+        BranchSpec scmBranch = new BranchSpec("*/github-branch");
+        GitHubBranch branch = GitHubBranch.create(scmBranch);
+
+        Assert.assertTrue(branch.matches(repo, "refs/heads/github-branch"));
+        Assert.assertTrue(branch.matches(repo, "github-branch"));
+    }
+
+    @Test
+    public void testBranchDoesNotMatch() throws Exception, InterruptedException {
+        GitHubRepositoryName repo = GitHubRepositoryName.create("github-repo");
+
+        BranchSpec scmBranch = new BranchSpec("*/github-branch");
+        GitHubBranch branch = GitHubBranch.create(scmBranch);
+
+        Assert.assertFalse(branch.matches(repo, "refs/heads/github-branch-2"));
+        Assert.assertFalse(branch.matches(repo, "github-branch-2"));
+    }
+
+    @Test
+    public void testRepoDoesNotMatch() throws Exception, InterruptedException {
+        GitHubRepositoryName repo = GitHubRepositoryName.create("github-repo");
+
+        BranchSpec scmBranch = new BranchSpec("github-repo-2/github-branch");
+        GitHubBranch branch = GitHubBranch.create(scmBranch);
+
+        Assert.assertFalse(branch.matches(repo, "refs/heads/github-branch"));
+        Assert.assertFalse(branch.matches(repo, "github-branch"));
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/GitHubPushTriggerTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GitHubPushTriggerTest.java
@@ -26,6 +26,7 @@ import static com.cloudbees.jenkins.GitHubWebHookFullTest.classpath;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.jenkinsci.plugins.github.webhook.subscriber.DefaultPushGHEventListenerTest.TRIGGERED_BY_USER_FROM_RESOURCE;
+import static org.jenkinsci.plugins.github.webhook.subscriber.DefaultPushGHEventListenerTest.TRIGGERED_BY_REF_FROM_RESOURCE;
 
 /**
  * @author lanwen (Merkushev Kirill)
@@ -69,7 +70,7 @@ public class GitHubPushTriggerTest {
         buildData.buildsByBranchName = new HashMap<String, Build>();
         buildData.getLastBuiltRevision().setSha1(ObjectId.zeroId());
 
-        trigger.onPost(TRIGGERED_BY_USER_FROM_RESOURCE);
+        trigger.onPost(TRIGGERED_BY_USER_FROM_RESOURCE, TRIGGERED_BY_REF_FROM_RESOURCE);
 
         TimeUnit.SECONDS.sleep(job.getQuietPeriod());
         jRule.waitUntilNoActivity();

--- a/src/test/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventListenerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventListenerTest.java
@@ -42,6 +42,7 @@ public class DefaultPushGHEventListenerTest {
 
     public static final GitSCM GIT_SCM_FROM_RESOURCE = new GitSCM("ssh://git@github.com/lanwen/test.git");
     public static final String TRIGGERED_BY_USER_FROM_RESOURCE = "lanwen";
+    public static final String TRIGGERED_BY_REF_FROM_RESOURCE = "refs/heads/master";    
 
     @Rule
     public JenkinsRule jenkins = new JenkinsRule();
@@ -110,6 +111,7 @@ public class DefaultPushGHEventListenerTest {
                 .withTimestamp(subscriberEvent.getTimestamp())
                 .withOrigin("shouldParsePushPayload")
                 .withTriggeredByUser(TRIGGERED_BY_USER_FROM_RESOURCE)
+                .withTriggeredByRef(TRIGGERED_BY_REF_FROM_RESOURCE)
                 .build()
         ));
     }
@@ -133,6 +135,7 @@ public class DefaultPushGHEventListenerTest {
                 .withTimestamp(subscriberEvent.getTimestamp())
                 .withOrigin("shouldReceivePushHookOnWorkflow")
                 .withTriggeredByUser(TRIGGERED_BY_USER_FROM_RESOURCE)
+                .withTriggeredByRef(TRIGGERED_BY_REF_FROM_RESOURCE)
                 .build()
         ));
     }

--- a/src/test/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventListenerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventListenerTest.java
@@ -3,7 +3,10 @@ package org.jenkinsci.plugins.github.webhook.subscriber;
 import com.cloudbees.jenkins.GitHubPushTrigger;
 import com.cloudbees.jenkins.GitHubRepositoryNameContributor;
 import com.cloudbees.jenkins.GitHubTriggerEvent;
+import com.cloudbees.jenkins.GitHubWebHook;
+
 import hudson.ExtensionList;
+import hudson.model.EnvironmentContributor;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.plugins.git.GitSCM;
@@ -75,14 +78,31 @@ public class DefaultPushGHEventListenerTest {
         Jenkins jenkins = mock(Jenkins.class);
         when(jenkins.getAllItems(Item.class)).thenReturn(Collections.singletonList(prj));
 
-        ExtensionList<GitHubRepositoryNameContributor> extensionList = mock(ExtensionList.class);
-        List<GitHubRepositoryNameContributor> gitHubRepositoryNameContributorList =
+        {
+            ExtensionList<GitHubRepositoryNameContributor> extensionList = mock(ExtensionList.class);
+            List<GitHubRepositoryNameContributor> gitHubRepositoryNameContributorList =
                 Collections.singletonList(new GitHubRepositoryNameContributor.FromSCM());
-        when(extensionList.iterator()).thenReturn(gitHubRepositoryNameContributorList.iterator());
-        when(jenkins.getExtensionList(GitHubRepositoryNameContributor.class)).thenReturn(extensionList);
+            when(extensionList.iterator()).thenReturn(gitHubRepositoryNameContributorList.iterator());
+            when(jenkins.getExtensionList(GitHubRepositoryNameContributor.class)).thenReturn(extensionList);
+        }
+
+        {
+            ExtensionList<EnvironmentContributor> extensionList = mock(ExtensionList.class);
+            List<EnvironmentContributor> environmentContributorList = Collections.emptyList();
+            when(extensionList.iterator()).thenReturn(environmentContributorList.iterator());
+            when(jenkins.getExtensionList(EnvironmentContributor.class)).thenReturn(extensionList);
+        }
+
+        {
+            ExtensionList<GitHubWebHook.Listener> extensionList = mock(ExtensionList.class);
+            List<GitHubWebHook.Listener> listenerList = Collections.emptyList();
+            when(extensionList.iterator()).thenReturn(listenerList.iterator());
+            when(jenkins.getExtensionList(GitHubWebHook.Listener.class)).thenReturn(extensionList);
+        }
 
         try (MockedStatic<Jenkins> mockedJenkins = mockStatic(Jenkins.class)) {
             mockedJenkins.when(Jenkins::getInstance).thenReturn(jenkins);
+            mockedJenkins.when(Jenkins::getInstanceOrNull).thenReturn(jenkins);
             new DefaultPushGHEventSubscriber().onEvent(subscriberEvent);
         }
 


### PR DESCRIPTION
The existing webhook handling code would trigger the GitSCM poll for the default branch regardless of whether or not the target ref of the webhook push event matched the branch specifier of the Job definition. This is problematic and often leads to duplicate builds for the same branch+revision if pushes to other branches happened to occur whilst build(s) were already in progress for that branch. This is because the GitSCM trigger just compares the HEAD revision of any branch matching the branch specifier against the last *completed* build of that branch (ignoring in-progress builds) and schedules a new build for it.

The code for this PR is mostly a rebased version of the original changes proposed by @aserrallerios under https://github.com/jenkinsci/github-plugin/pull/44 with some small refinements.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/270)
<!-- Reviewable:end -->
