### PR TITLE
build: Realign plugin with LTS version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    target-branch: master
+    labels:
+      - dependencies

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
         <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
         <url>https://github.com/${gitHubRepo}</url>
         <tag>${scmTag}</tag>
@@ -50,7 +50,7 @@
         <revision>1.34.4</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/github-plugin</gitHubRepo>
-        <jenkins.version>2.346</jenkins.version>
+        <jenkins.version>2.346.1</jenkins.version>
         <release.skipTests>false</release.skipTests>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <findbugs-maven-plugin.version>3.0.4</findbugs-maven-plugin.version>
@@ -226,7 +226,7 @@
         <dependency>
             <groupId>com.tngtech.java</groupId>
             <artifactId>junit-dataprovider</artifactId>
-            <version>1.10.0</version>
+            <version>1.13.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -234,14 +234,14 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8-standalone</artifactId>
-            <version>2.32.0</version>
+            <version>2.33.2</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
-            <version>4.3.3</version>
+            <version>5.1.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -251,8 +251,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.332.x</artifactId>
-                <version>1181.v04b_21d4b_0d6c</version>
+                <artifactId>bom-2.346.x</artifactId>
+                <version>1438.v6a_2c29d73f82</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -279,7 +279,7 @@
 
             <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.1.2</version>
                 <executions>
                     <execution>
                         <id>checkstyle</id>


### PR DESCRIPTION
As the title says, the plugin baseline has been realigned with the newest LTS release, 2.346.1, which contains the API needed for the recent symbol usage.
Additionally I've updated a few dependencies to prevent enforcer conflicts.

Would you be so kind to cut a release afterwards to make this plugin available for LTS users again @KostyaSha ?