### PR TITLE
Upgrade plugin parent POM, SpotBugs, Hamcrest, and Mockito; fix Javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.40</version>
+        <version>4.45</version>
         <relativePath />
     </parent>
 
@@ -52,15 +52,7 @@
         <gitHubRepo>jenkinsci/github-plugin</gitHubRepo>
         <jenkins.version>2.346.1</jenkins.version>
         <release.skipTests>false</release.skipTests>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <findbugs-maven-plugin.version>3.0.4</findbugs-maven-plugin.version>
-        <hamcrest.version>2.2</hamcrest.version>
-        <concurrency>1</concurrency>
-        <workflow.version>1.14.2</workflow.version>
         <tagNameFormat>v@{project.version}</tagNameFormat>
-        <spotbugs.threshold>Low</spotbugs.threshold>
-        <spotbugs.effort>Max</spotbugs.effort>
-        <spotbugs.failOnError>false</spotbugs.failOnError>
     </properties>
 
     <repositories>
@@ -147,36 +139,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-            <version>${hamcrest.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <!-- This is needed in order to force junit4 and JTH tests to use newer hamcrest version -->
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <version>${hamcrest.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <version>${hamcrest.version}</version>
-            <scope>test</scope>
-        </dependency>
-      
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
@@ -2,6 +2,7 @@ package com.cloudbees.jenkins;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.Util;
 import hudson.XmlFile;
@@ -270,6 +271,10 @@ public class GitHubPushTrigger extends Trigger<Job<?, ?>> implements GitHubTrigg
          *
          * @since 1.350
          */
+        @SuppressFBWarnings(
+                value = "RV_RETURN_VALUE_IGNORED",
+                justification =
+                        "method signature does not permit plumbing through the return value")
         public void writeLogTo(XMLOutput out) throws IOException {
             new AnnotatedLargeText<GitHubWebHookPollingAction>(getLogFileForJob(job), Charsets.UTF_8, true, this)
                     .writeHtmlTo(0, out.asWriter());

--- a/src/main/java/com/coravy/hudson/plugins/github/GithubLinkAction.java
+++ b/src/main/java/com/coravy/hudson/plugins/github/GithubLinkAction.java
@@ -12,7 +12,7 @@ import java.util.Collections;
 /**
  * Add the Github Logo/Icon to the sidebar.
  *
- * @author Stefan Saasen <stefan@coravy.com>
+ * @author <a href="mailto:stefan@coravy.com">Stefan Saasen</a>
  */
 public final class GithubLinkAction implements Action {
 

--- a/src/main/java/com/coravy/hudson/plugins/github/GithubLinkAnnotator.java
+++ b/src/main/java/com/coravy/hudson/plugins/github/GithubLinkAnnotator.java
@@ -17,11 +17,11 @@ import java.util.regex.Pattern;
  * <p>
  * It's based on the TracLinkAnnotator.
  * <p>
- *
- * @author Stefan Saasen <stefan@coravy.com>
- * @todo Change the annotator to use GithubUrl instead of the String url.
+ * TODO Change the annotator to use GithubUrl instead of the String url.
  * Knowledge about the github url structure should be encapsulated in
  * GithubUrl.
+ *
+ * @author <a href="mailto:stefan@coravy.com">Stefan Saasen</a>
  */
 @Extension
 public class GithubLinkAnnotator extends ChangeLogAnnotator {

--- a/src/main/java/com/coravy/hudson/plugins/github/GithubProjectProperty.java
+++ b/src/main/java/com/coravy/hudson/plugins/github/GithubProjectProperty.java
@@ -24,7 +24,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
  * - URL to the GitHub project
  * - Build status context name
  *
- * @author Stefan Saasen <stefan@coravy.com>
+ * @author <a href="mailto:stefan@coravy.com">Stefan Saasen</a>
  */
 public final class GithubProjectProperty extends JobProperty<Job<?, ?>> {
 

--- a/src/main/java/com/coravy/hudson/plugins/github/GithubUrl.java
+++ b/src/main/java/com/coravy/hudson/plugins/github/GithubUrl.java
@@ -3,7 +3,7 @@ package com.coravy.hudson.plugins.github;
 import org.apache.commons.lang.StringUtils;
 
 /**
- * @author Stefan Saasen <stefan@coravy.com>
+ * @author <a href="mailto:stefan@coravy.com">Stefan Saasen</a>
  */
 public final class GithubUrl {
 

--- a/src/main/java/org/jenkinsci/plugins/github/admin/GitHubHookRegisterProblemMonitor.java
+++ b/src/main/java/org/jenkinsci/plugins/github/admin/GitHubHookRegisterProblemMonitor.java
@@ -32,7 +32,7 @@ import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 
 /**
  * Administrative monitor to track problems of registering/removing hooks for GH.
- * Holds non-savable map of repo->message and persisted list of ignored projects.
+ * Holds non-savable map of repo-&gt;message and persisted list of ignored projects.
  * Anyone can register new problem with {@link #registerProblem(GitHubRepositoryName, Throwable)} and check
  * repo for problems with {@link #isProblemWith(GitHubRepositoryName)}
  *
@@ -64,7 +64,7 @@ public class GitHubHookRegisterProblemMonitor extends AdministrativeMonitor impl
     }
 
     /**
-     * @return Immutable copy of map with repo->problem message content
+     * @return Immutable copy of map with repo-&gt;problem message content
      */
     public Map<GitHubRepositoryName, String> getProblems() {
         return ImmutableMap.copyOf(problems);

--- a/src/main/java/org/jenkinsci/plugins/github/config/GitHubServerConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/github/config/GitHubServerConfig.java
@@ -214,7 +214,7 @@ public class GitHubServerConfig extends AbstractDescribableImpl<GitHubServerConf
     }
 
     /**
-     * @param clientCacheSize capacity of cache for GitHub client in MB, set to <= 0 to turn off this feature
+     * @param clientCacheSize capacity of cache for GitHub client in MB, set to &lt;= 0 to turn off this feature
      */
     @DataBoundSetter
     public void setClientCacheSize(int clientCacheSize) {

--- a/src/main/java/org/jenkinsci/plugins/github/util/BuildDataHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/github/util/BuildDataHelper.java
@@ -15,7 +15,7 @@ import java.util.Set;
 /**
  * Stores common methods for {@link BuildData} handling.
  *
- * @author Oleg Nenashev <o.v.nenashev@gmail.com>
+ * @author <a href="mailto:o.v.nenashev@gmail.com">Oleg Nenashev</a>
  * @since 1.10
  */
 public final class BuildDataHelper {

--- a/src/main/java/org/jenkinsci/plugins/github/webhook/RequirePostWithGHHookPayload.java
+++ b/src/main/java/org/jenkinsci/plugins/github/webhook/RequirePostWithGHHookPayload.java
@@ -81,7 +81,7 @@ public @interface RequirePostWithGHHookPayload {
         }
 
         /**
-         * Duplicates {@link @org.kohsuke.stapler.interceptor.RequirePOST} precheck.
+         * Duplicates {@link org.kohsuke.stapler.interceptor.RequirePOST} precheck.
          * As of it can't guarantee order of multiply interceptor calls,
          * it should implement all features of required interceptors in one class
          *

--- a/src/test/java/com/cloudbees/jenkins/GitHubCommitNotifierTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GitHubCommitNotifierTest.java
@@ -18,9 +18,9 @@ import org.jenkinsci.plugins.github.config.GitHubPluginConfig;
 import org.jenkinsci.plugins.github.test.GHMockRule;
 import org.jenkinsci.plugins.github.test.GHMockRule.FixedGHRepoNameTestContributor;
 import org.jenkinsci.plugins.github.test.InjectJenkinsMembersRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExternalResource;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.Issue;
@@ -28,7 +28,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
 import org.jvnet.hudson.test.TestExtension;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.inject.Inject;
 
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.when;
 /**
  * Tests for {@link GitHubCommitNotifier}.
  *
- * @author Oleg Nenashev <o.v.nenashev@gmail.com>
+ * @author <a href="mailto:o.v.nenashev@gmail.com">Oleg Nenashev</a>
  */
 @RunWith(MockitoJUnitRunner.class)
 public class GitHubCommitNotifierTest {
@@ -72,15 +72,12 @@ public class GitHubCommitNotifierTest {
             .stubStatuses();
 
 
-    @Rule
-    public ExternalResource prep = new ExternalResource() {
-        @Override
-        protected void before() throws Throwable {
+    @Before
+    public void before() throws Throwable {
             when(data.getLastBuiltRevision()).thenReturn(rev);
             data.lastBuild = new hudson.plugins.git.util.Build(rev, rev, 0, Result.SUCCESS);
             when(rev.getSha1()).thenReturn(ObjectId.fromString(SOME_SHA));
-        }
-    };
+    }
 
     @Test
     @Issue("JENKINS-23641")

--- a/src/test/java/com/cloudbees/jenkins/GitHubSetCommitStatusBuilderTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GitHubSetCommitStatusBuilderTest.java
@@ -17,9 +17,9 @@ import org.jenkinsci.plugins.github.config.GitHubPluginConfig;
 import org.jenkinsci.plugins.github.test.GHMockRule;
 import org.jenkinsci.plugins.github.test.GHMockRule.FixedGHRepoNameTestContributor;
 import org.jenkinsci.plugins.github.test.InjectJenkinsMembersRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExternalResource;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.Issue;
@@ -28,7 +28,7 @@ import org.jvnet.hudson.test.TestBuilder;
 import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.recipes.LocalData;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.inject.Inject;
 import java.util.List;
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.when;
 /**
  * Tests for {@link GitHubSetCommitStatusBuilder}.
  *
- * @author Oleg Nenashev <o.v.nenashev@gmail.com>
+ * @author <a href="mailto:o.v.nenashev@gmail.com">Oleg Nenashev</a>
  */
 @RunWith(MockitoJUnitRunner.class)
 public class GitHubSetCommitStatusBuilderTest {
@@ -72,15 +72,12 @@ public class GitHubSetCommitStatusBuilderTest {
             .stubRepo()
             .stubStatuses();
 
-    @Rule
-    public ExternalResource prep = new ExternalResource() {
-        @Override
-        protected void before() throws Throwable {
+    @Before
+    public void before() throws Throwable {
             when(data.getLastBuiltRevision()).thenReturn(rev);
             data.lastBuild = new hudson.plugins.git.util.Build(rev, rev, 0, Result.SUCCESS);
             when(rev.getSha1()).thenReturn(ObjectId.fromString(SOME_SHA));
-        }
-    };
+    }
 
     @Test
     @Issue("JENKINS-23641")

--- a/src/test/java/com/cloudbees/jenkins/GitHubWebHookCrumbExclusionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GitHubWebHookCrumbExclusionTest.java
@@ -7,8 +7,8 @@ import javax.servlet.FilterChain;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;

--- a/src/test/java/com/cloudbees/jenkins/GitHubWebHookTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GitHubWebHookTest.java
@@ -20,7 +20,7 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author lanwen (Merkushev Kirill)

--- a/src/test/java/com/cloudbees/jenkins/GlobalConfigSubmitTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GlobalConfigSubmitTest.java
@@ -14,7 +14,6 @@ import java.net.URL;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 
 /**
  * Test Class for {@link GitHubPushTrigger}.

--- a/src/test/java/com/coravy/hudson/plugins/github/GitHubRepositoryNameTest.java
+++ b/src/test/java/com/coravy/hudson/plugins/github/GitHubRepositoryNameTest.java
@@ -15,7 +15,7 @@ import static org.jenkinsci.plugins.github.test.GitHubRepoNameMatchers.repo;
 import static org.jenkinsci.plugins.github.test.GitHubRepoNameMatchers.withHost;
 import static org.jenkinsci.plugins.github.test.GitHubRepoNameMatchers.withRepoName;
 import static org.jenkinsci.plugins.github.test.GitHubRepoNameMatchers.withUserName;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Unit tests of {@link GitHubRepositoryName}

--- a/src/test/java/com/coravy/hudson/plugins/github/GithubLinkActionFactoryTest.java
+++ b/src/test/java/com/coravy/hudson/plugins/github/GithubLinkActionFactoryTest.java
@@ -3,7 +3,7 @@ package com.coravy.hudson.plugins.github;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.empty;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.util.Collection;

--- a/src/test/java/com/coravy/hudson/plugins/github/GithubProjectPropertyTest.java
+++ b/src/test/java/com/coravy/hudson/plugins/github/GithubProjectPropertyTest.java
@@ -4,7 +4,9 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.structs.DescribableHelper;
 import org.junit.Ignore;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import org.junit.Rule;
 import org.jvnet.hudson.test.JenkinsRule;
 

--- a/src/test/java/com/coravy/hudson/plugins/github/GithubUrlTest.java
+++ b/src/test/java/com/coravy/hudson/plugins/github/GithubUrlTest.java
@@ -1,6 +1,6 @@
 package com.coravy.hudson.plugins.github;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.After;
 import org.junit.Before;

--- a/src/test/java/org/jenkinsci/plugins/github/admin/GHRepoNameTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/admin/GHRepoNameTest.java
@@ -5,11 +5,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kohsuke.stapler.StaplerRequest;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 /**

--- a/src/test/java/org/jenkinsci/plugins/github/admin/GitHubHookRegisterProblemMonitorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/admin/GitHubHookRegisterProblemMonitorTest.java
@@ -23,7 +23,7 @@ import org.kohsuke.github.GHEvent;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.inject.Inject;
 import java.io.IOException;
@@ -39,7 +39,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 /**

--- a/src/test/java/org/jenkinsci/plugins/github/admin/ValidateRepoNameTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/admin/ValidateRepoNameTest.java
@@ -9,7 +9,7 @@ import org.kohsuke.stapler.Function;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.lang.reflect.InvocationTargetException;
 

--- a/src/test/java/org/jenkinsci/plugins/github/common/CombineErrorHandlerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/common/CombineErrorHandlerTest.java
@@ -11,7 +11,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collections;
 
@@ -20,7 +20,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.is;
 import static org.jenkinsci.plugins.github.common.CombineErrorHandler.errorHandling;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;

--- a/src/test/java/org/jenkinsci/plugins/github/config/ConfigAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/config/ConfigAsCodeTest.java
@@ -13,7 +13,11 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.jenkinsci.plugins.github.test.GitHubServerConfigMatcher.*;
 
 public class ConfigAsCodeTest {

--- a/src/test/java/org/jenkinsci/plugins/github/config/GitHubServerConfigTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/config/GitHubServerConfigTest.java
@@ -10,7 +10,7 @@ import static org.jenkinsci.plugins.github.config.GitHubServerConfig.GITHUB_URL;
 import static org.jenkinsci.plugins.github.config.GitHubServerConfig.allowedToManageHooks;
 import static org.jenkinsci.plugins.github.config.GitHubServerConfig.isUrlCustom;
 import static org.jenkinsci.plugins.github.config.GitHubServerConfig.withHost;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author lanwen (Merkushev Kirill)

--- a/src/test/java/org/jenkinsci/plugins/github/config/HookSecretConfigTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/config/HookSecretConfigTest.java
@@ -36,7 +36,7 @@ public class HookSecretConfigTest {
 
         hookSecretConfig = GitHubPlugin.configuration().getHookSecretConfig();
         assertNotNull("Secret is persistent", hookSecretConfig.getHookSecret());
-        assertTrue("Secret correctly stored", SECRET_INIT.equals(hookSecretConfig.getHookSecret().getPlainText()));
+        assertEquals("Secret correctly stored", SECRET_INIT, hookSecretConfig.getHookSecret().getPlainText());
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/github/extension/CryptoUtilTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/extension/CryptoUtilTest.java
@@ -7,7 +7,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.jenkinsci.plugins.github.webhook.GHWebhookSignature.webhookSignature;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Tests for utility class that deals with crypto/hashing of data.

--- a/src/test/java/org/jenkinsci/plugins/github/internal/GitHubClientCacheCleanupTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/internal/GitHubClientCacheCleanupTest.java
@@ -21,8 +21,6 @@ import static java.nio.file.Files.newDirectoryStream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.startsWith;
 import static org.jenkinsci.plugins.github.internal.GitHubClientCacheOps.clearRedundantCaches;
 import static org.jenkinsci.plugins.github.internal.GitHubClientCacheOps.getBaseCacheDir;
 import static org.junit.Assume.assumeThat;

--- a/src/test/java/org/jenkinsci/plugins/github/status/GitHubCommitStatusSetterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/status/GitHubCommitStatusSetterTest.java
@@ -23,16 +23,16 @@ import org.jenkinsci.plugins.github.status.sources.DefaultStatusResultSource;
 import org.jenkinsci.plugins.github.test.GHMockRule;
 import org.jenkinsci.plugins.github.test.GHMockRule.FixedGHRepoNameTestContributor;
 import org.jenkinsci.plugins.github.test.InjectJenkinsMembersRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExternalResource;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
 import org.jvnet.hudson.test.TestExtension;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.inject.Inject;
 import java.util.Collections;
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.when;
 /**
  * Tests for {@link GitHubSetCommitStatusBuilder}.
  *
- * @author Oleg Nenashev <o.v.nenashev@gmail.com>
+ * @author <a href="mailto:o.v.nenashev@gmail.com">Oleg Nenashev</a>
  */
 @RunWith(MockitoJUnitRunner.class)
 public class GitHubCommitStatusSetterTest {
@@ -75,15 +75,12 @@ public class GitHubCommitStatusSetterTest {
             .stubRepo()
             .stubStatuses();
 
-    @Rule
-    public ExternalResource prep = new ExternalResource() {
-        @Override
-        protected void before() throws Throwable {
+    @Before
+    public void before() throws Throwable {
             when(data.getLastBuiltRevision()).thenReturn(rev);
             data.lastBuild = new hudson.plugins.git.util.Build(rev, rev, 0, Result.SUCCESS);
             when(rev.getSha1()).thenReturn(ObjectId.fromString(SOME_SHA));
-        }
-    };
+    }
 
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/github/status/err/ErrorHandlersTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/status/err/ErrorHandlersTest.java
@@ -7,10 +7,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
 
 /**

--- a/src/test/java/org/jenkinsci/plugins/github/status/sources/BuildRefBackrefSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/status/sources/BuildRefBackrefSourceTest.java
@@ -10,13 +10,10 @@ import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.mockito.Answers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.when;
 
 /**
  * @author pupssman (Kalinin Ivan)

--- a/src/test/java/org/jenkinsci/plugins/github/status/sources/ConditionalStatusResultSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/status/sources/ConditionalStatusResultSourceTest.java
@@ -11,7 +11,7 @@ import org.junit.runner.RunWith;
 import org.kohsuke.github.GHCommitState;
 import org.mockito.Answers;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collections;
 
@@ -19,7 +19,7 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.jenkinsci.plugins.github.status.sources.misc.BetterThanOrEqualBuildResult.betterThanOrEqualTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 /**

--- a/src/test/java/org/jenkinsci/plugins/github/status/sources/ManuallyEnteredRepositorySourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/status/sources/ManuallyEnteredRepositorySourceTest.java
@@ -7,16 +7,16 @@ import org.junit.runner.RunWith;
 import org.kohsuke.github.GHRepository;
 import org.mockito.Answers;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.PrintStream;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/org/jenkinsci/plugins/github/status/sources/ManuallyEnteredSourcesTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/status/sources/ManuallyEnteredSourcesTest.java
@@ -6,12 +6,12 @@ import hudson.model.TaskListener;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Answers;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 /**
@@ -34,7 +34,7 @@ public class ManuallyEnteredSourcesTest {
     @Test
     public void shouldExpandContext() throws Exception {
         when(run.getEnvironment(listener)).thenReturn(env);
-        when(env.expand(Matchers.anyString())).thenReturn(EXPANDED);
+        when(env.expand(ArgumentMatchers.anyString())).thenReturn(EXPANDED);
 
         String context = new ManuallyEnteredCommitContextSource("").context(run, listener);
         assertThat(context, equalTo(EXPANDED));
@@ -43,7 +43,7 @@ public class ManuallyEnteredSourcesTest {
     @Test
     public void shouldExpandSha() throws Exception {
         when(run.getEnvironment(listener)).thenReturn(env);
-        when(env.expand(Matchers.anyString())).thenReturn(EXPANDED);
+        when(env.expand(ArgumentMatchers.anyString())).thenReturn(EXPANDED);
 
         String context = new ManuallyEnteredShaSource("").get(run, listener);
         assertThat(context, equalTo(EXPANDED));
@@ -52,7 +52,7 @@ public class ManuallyEnteredSourcesTest {
     @Test
     public void shouldExpandBackref() throws Exception {
         when(run.getEnvironment(listener)).thenReturn(env);
-        when(env.expand(Matchers.anyString())).thenReturn(EXPANDED);
+        when(env.expand(ArgumentMatchers.anyString())).thenReturn(EXPANDED);
 
         String context = new ManuallyEnteredBackrefSource("").get(run, listener);
         assertThat(context, equalTo(EXPANDED));

--- a/src/test/java/org/jenkinsci/plugins/github/status/sources/misc/AnyBuildResultTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/status/sources/misc/AnyBuildResultTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kohsuke.github.GHCommitState;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.verifyNoMoreInteractions;

--- a/src/test/java/org/jenkinsci/plugins/github/status/sources/misc/BetterThanOrEqualBuildResultTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/status/sources/misc/BetterThanOrEqualBuildResultTest.java
@@ -16,7 +16,7 @@ import org.mockito.junit.MockitoRule;
 
 import static org.hamcrest.Matchers.is;
 import static org.jenkinsci.plugins.github.status.sources.misc.BetterThanOrEqualBuildResult.betterThanOrEqualTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author lanwen (Merkushev Kirill)

--- a/src/test/java/org/jenkinsci/plugins/github/util/JobInfoHelpersTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/util/JobInfoHelpersTest.java
@@ -14,7 +14,7 @@ import static org.jenkinsci.plugins.github.util.JobInfoHelpers.isAlive;
 import static org.jenkinsci.plugins.github.util.JobInfoHelpers.isBuildable;
 import static org.jenkinsci.plugins.github.util.JobInfoHelpers.triggerFrom;
 import static org.jenkinsci.plugins.github.util.JobInfoHelpers.withTrigger;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author lanwen (Merkushev Kirill)

--- a/src/test/java/org/jenkinsci/plugins/github/webhook/GHEventHeaderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/webhook/GHEventHeaderTest.java
@@ -5,7 +5,7 @@ import org.junit.runner.RunWith;
 import org.kohsuke.github.GHEvent;
 import org.kohsuke.stapler.StaplerRequest;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;

--- a/src/test/java/org/jenkinsci/plugins/github/webhook/GHEventPayloadTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/webhook/GHEventPayloadTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kohsuke.stapler.StaplerRequest;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;

--- a/src/test/java/org/jenkinsci/plugins/github/webhook/RequirePostWithGHHookPayloadTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/webhook/RequirePostWithGHHookPayloadTest.java
@@ -10,7 +10,7 @@ import org.kohsuke.github.GHEvent;
 import org.kohsuke.stapler.StaplerRequest;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.lang.reflect.InvocationTargetException;
 

--- a/src/test/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventListenerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventListenerTest.java
@@ -17,7 +17,7 @@ import org.mockito.Mockito;
 import static com.cloudbees.jenkins.GitHubWebHookFullTest.classpath;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
This PR updates the plugin parent POM to the latest version and does some cleanup:

- Fix Javadoc errors
- Use our latest standard SpotBugs configuration
- Upgrade Hamcrest and Mockito to the latest versions

The Mockito upgrade required a lot of changes to test imports.

CC @KostyaSha @oleg-nenashev