### PR TITLE
Use `instance-identity` as a plugin rather than a module

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,4 @@
-buildPlugin(configurations: [
-                [platform: 'linux', jdk: '8'],
+buildPlugin(useContainerAgent: true, configurations: [
                 [platform: 'linux', jdk: '11'],
                 [platform: 'windows', jdk: '11'],
             ])

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <revision>1.34.6</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/github-plugin</gitHubRepo>
-        <jenkins.version>2.346.1</jenkins.version>
+        <jenkins.version>2.357</jenkins.version>
         <release.skipTests>false</release.skipTests>
         <tagNameFormat>v@{project.version}</tagNameFormat>
     </properties>
@@ -119,8 +119,7 @@
         <dependency>
             <groupId>org.jenkins-ci.modules</groupId>
             <artifactId>instance-identity</artifactId>
-            <version>2.2</version>
-            <scope>provided</scope><!-- https://wiki.jenkins.io/display/JENKINS/Instance+Identity "add a provided scope dependency to this module into your plugin" -->
+            <version>116.vf8f487400980</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
@@ -263,7 +263,7 @@ public class GitHubPushTrigger extends Trigger<Job<?, ?>> implements GitHubTrigg
         }
 
         public String getLog() throws IOException {
-            return Util.loadFile(getLogFileForJob(job));
+            return Util.loadFile(getLogFileForJob(Objects.requireNonNull(job)));
         }
 
         /**
@@ -276,7 +276,11 @@ public class GitHubPushTrigger extends Trigger<Job<?, ?>> implements GitHubTrigg
                 justification =
                         "method signature does not permit plumbing through the return value")
         public void writeLogTo(XMLOutput out) throws IOException {
-            new AnnotatedLargeText<GitHubWebHookPollingAction>(getLogFileForJob(job), Charsets.UTF_8, true, this)
+            new AnnotatedLargeText<GitHubWebHookPollingAction>(
+                            getLogFileForJob(Objects.requireNonNull(job)),
+                            Charsets.UTF_8,
+                            true,
+                            this)
                     .writeHtmlTo(0, out.asWriter());
         }
     }


### PR DESCRIPTION
Not needed for BOM in the short term, but a generally positive maintenance step IMHO. CC @jglick