### PR TITLE
Register XStream alias even earlier

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github/GitHubPlugin.java
+++ b/src/main/java/org/jenkinsci/plugins/github/GitHubPlugin.java
@@ -43,10 +43,6 @@ public class GitHubPlugin extends Plugin {
         new Migrator().migrate();
     }
 
-    @Override
-    public void start() throws Exception {
-    }
-
     /**
      * Shortcut method for getting instance of {@link GitHubPluginConfig}.
      *

--- a/src/main/java/org/jenkinsci/plugins/github/GitHubPlugin.java
+++ b/src/main/java/org/jenkinsci/plugins/github/GitHubPlugin.java
@@ -7,6 +7,8 @@ import org.jenkinsci.plugins.github.config.GitHubPluginConfig;
 import org.jenkinsci.plugins.github.migration.Migrator;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 
@@ -23,6 +25,8 @@ public class GitHubPlugin extends Plugin {
      * Launched before plugin starts
      * Adds alias for {@link GitHubPlugin} to simplify resulting xml.
      */
+    @Initializer(before = InitMilestone.SYSTEM_CONFIG_LOADED)
+    @Restricted(DoNotUse.class)
     public static void addXStreamAliases() {
         Migrator.enableCompatibilityAliases();
         Migrator.enableAliases();
@@ -41,7 +45,6 @@ public class GitHubPlugin extends Plugin {
 
     @Override
     public void start() throws Exception {
-        addXStreamAliases();
     }
 
     /**


### PR DESCRIPTION
There has been a change in the git plugin that somehow makes `GitHubPluginConfig` load earlier than `GitHubPlugin.start()`
So when running the `MigratorTest` with git plugin 4.12.1 installed (for example during PCT) it fails because the old configuration could not be loaded.

The fix is simply to register the XStream alias before `InitMilestone.SYSTEM_CONFIG_LOADED`  instead of `GitHubPlugin.start()`.

I've verified that it works by temporarily adding the git plugin as a test dependency in the pom of this plugin, and the `MigratorTest` fails before this change and succeeds after the fix got applied.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
