### PR TITLE
[JENKINS-69353] github-plugin test failure on Java 17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildPlugin(useContainerAgent: true, configurations: [
-                [platform: 'linux', jdk: '11'],
-                [platform: 'windows', jdk: '11'],
-            ])
+    [platform: 'linux', jdk: 17],
+    [platform: 'windows', jdk: 11],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-inline</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Serializing mock triggers is no longer supported in Java 17, so instead switch to a pure mock-based approach that does not require serialization. Tested by successfully running `mvn clean verify -Dtest=org.jenkinsci.plugins.github.webhook.subscriber.DefaultPushGHEventListenerTest` on both Java 11 and 17.

CC @KostyaSha 