### PR TITLE
Replace Prototype.js with native JavaScript

### DIFF
--- a/src/main/webapp/js/warning.js
+++ b/src/main/webapp/js/warning.js
@@ -14,18 +14,27 @@ var InlineWarning = (function () {
 
     exports.start = function () {
         // Ignore when GH trigger unchecked
-        if (!$$(options.input).first().checked) {
+        if (!document.querySelector(options.input).checked) {
             return;
         }
-        new Ajax.PeriodicalUpdater(
-            options.id,
-            options.url,
-            {
-                method: 'get',
-                frequency: 10,
-                decay: 2
-            }
-        );
+        var frequency = 10;
+        var decay = 2;
+        var lastResponseText;
+        var fetchData = function () {
+            fetch(options.url).then((rsp) => {
+                rsp.text().then((responseText) => {
+                    if (responseText !== lastResponseText) {
+                        document.getElementById(options.id).innerHTML = responseText;
+                        lastResponseText = responseText;
+                        frequency = 10;
+                    } else {
+                        frequency *= decay;
+                    }
+                    setTimeout(fetchData, frequency * 1000);
+                });
+            });
+        };
+        fetchData();
     };
 
     return exports;


### PR DESCRIPTION
See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, this PR removes any usages of it in favor of native JavaScript APIs. To test this, I installed this plugin on a custom build of Jenkins that had Prototype ripped out (a local project branch), created a Freestyle project with the trigger from this plugin, and then put a breakpoint in my browser's JavaScript console and stepped through the changed lines to make sure they worked correctly.