### PR TITLE
Forward compatibility with Guice 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.72</version>
+        <version>4.77</version>
         <relativePath />
     </parent>
 
@@ -50,7 +50,7 @@
         <revision>1.37.3.2</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/github-plugin</gitHubRepo>
-        <jenkins.version>2.387.3</jenkins.version>
+        <jenkins.version>2.414.3</jenkins.version>
         <release.skipTests>false</release.skipTests>
         <tagNameFormat>v@{project.version}</tagNameFormat>
     </properties>
@@ -197,8 +197,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.387.x</artifactId>
-                <version>2329.v078520e55c19</version>
+                <artifactId>bom-2.414.x</artifactId>
+                <version>2718.v7e8a_d43b_3f0b_</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
@@ -40,7 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;

--- a/src/main/java/org/jenkinsci/plugins/github/admin/GitHubHookRegisterProblemMonitor.java
+++ b/src/main/java/org/jenkinsci/plugins/github/admin/GitHubHookRegisterProblemMonitor.java
@@ -21,7 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;

--- a/src/main/java/org/jenkinsci/plugins/github/config/GitHubPluginConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/github/config/GitHubPluginConfig.java
@@ -29,7 +29,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;

--- a/src/main/java/org/jenkinsci/plugins/github/webhook/subscriber/PingGHEventSubscriber.java
+++ b/src/main/java/org/jenkinsci/plugins/github/webhook/subscriber/PingGHEventSubscriber.java
@@ -6,7 +6,7 @@ import hudson.model.Item;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Set;
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import org.jenkinsci.plugins.github.admin.GitHubHookRegisterProblemMonitor;
 import org.jenkinsci.plugins.github.extension.GHEventsSubscriber;
 import org.kohsuke.github.GHEvent;

--- a/src/test/java/com/cloudbees/jenkins/GitHubCommitNotifierTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GitHubCommitNotifierTest.java
@@ -30,7 +30,7 @@ import org.jvnet.hudson.test.TestExtension;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import static com.cloudbees.jenkins.GitHubSetCommitStatusBuilderTest.SOME_SHA;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;

--- a/src/test/java/com/cloudbees/jenkins/GitHubPushTriggerTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GitHubPushTriggerTest.java
@@ -17,7 +17,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;

--- a/src/test/java/com/cloudbees/jenkins/GitHubSetCommitStatusBuilderTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GitHubSetCommitStatusBuilderTest.java
@@ -30,7 +30,7 @@ import org.jvnet.hudson.test.recipes.LocalData;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.util.List;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;

--- a/src/test/java/com/cloudbees/jenkins/GitHubWebHookFullTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GitHubWebHookFullTest.java
@@ -16,7 +16,7 @@ import org.junit.rules.ExternalResource;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.kohsuke.github.GHEvent;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 

--- a/src/test/java/org/jenkinsci/plugins/github/admin/GitHubHookRegisterProblemMonitorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/admin/GitHubHookRegisterProblemMonitorTest.java
@@ -25,7 +25,7 @@ import org.kohsuke.github.GitHub;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/org/jenkinsci/plugins/github/status/GitHubCommitStatusSetterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/status/GitHubCommitStatusSetterTest.java
@@ -34,7 +34,7 @@ import org.jvnet.hudson.test.TestExtension;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.util.Collections;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;


### PR DESCRIPTION
Without dropping compatibility with Guice 6 (currently delivered by Jenkins core), add support for Guice 7.