### PR TITLE
[JENKINS-70548] Allow GitHub Webhooks to be created by users with custom roles

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github/webhook/WebhookManager.java
+++ b/src/main/java/org/jenkinsci/plugins/github/webhook/WebhookManager.java
@@ -166,18 +166,14 @@ public class WebhookManager {
     }
 
     private GHRepository repoWithWebhookAccess(GitHubRepositoryName name) {
-        FluentIterableWrapper<GHRepository> reposAllowedtoManageWebhooks = from(name.resolve(allowedToManageHooks()));
-        if (!reposAllowedtoManageWebhooks.first().isPresent()) {
+        FluentIterableWrapper<GHRepository> reposAllowedToManageWebhooks = from(name.resolve(allowedToManageHooks()));
+        if (!reposAllowedToManageWebhooks.first().isPresent()) {
             LOGGER.debug("There are no github repos configured to allow webhook management for: {}", name);
             return null;
         }
-        com.google.common.base.Optional<GHRepository> repoWithAdminAccess = reposAllowedtoManageWebhooks
-                .firstMatch(withAdminAccess());
-        if (!repoWithAdminAccess.isPresent()) {
-            LOGGER.debug("None of the github repos configured have admin access for: {}", name);
-            return null;
-        }
-        GHRepository repo = repoWithAdminAccess.get();
+        com.google.common.base.Optional<GHRepository> repoAllowedToManageWebhooks = reposAllowedToManageWebhooks
+                .first();
+        GHRepository repo = repoAllowedToManageWebhooks.get();
         return repo;
     }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Would really like for custom roles to be used in management of Webhooks, because otherwise Jenkins needs to have admin permissions on every repository where managed Webhooks are desired. This is my attempt at making this possible.

- Remove admin check, `allowedToManageHooks()` is enough.

Intended to solve https://issues.jenkins.io/browse/JENKINS-70548.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

Passing tests and building successfully. A change in tests does not appear to be required.

```
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  04:14 min
[INFO] Finished at: 2024-01-24T16:22:27-07:00
[INFO] ------------------------------------------------------------------------
```

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
