### PR TITLE
[JENKINS-66079] Allow setting hookUrl from the global configuration page

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github/config/GitHubPluginConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/github/config/GitHubPluginConfig.java
@@ -193,6 +193,11 @@ public class GitHubPluginConfig extends GlobalConfiguration {
         hookSecretConfigs = null; // form binding might omit empty lists
         try {
             req.bindJSON(this, json);
+            // There is a type mismatch between the getter and the setter, so the bindJSON doesn't save
+            // the hookUrl properly
+            if (json != null && json.containsKey("hookUrl")) {
+                this.setHookUrl(json.getString("hookUrl"));
+            }
         } catch (Exception e) {
             LOGGER.debug("Problem while submitting form for GitHub Plugin ({})", e.getMessage(), e);
             LOGGER.trace("GH form data: {}", json.toString());


### PR DESCRIPTION
This PR fixes JENKINS-66079. 

It is actually not possible to set hookUrl from the global config page since 2019. The hookUrl setter is not recognized by the bindJSON code since the input parameter type change from URL to String.

The following test crashes with the code prior to my changes :
```
@Test
public void hookUrlShouldHaveAWriteMethod() throws Throwable {
    PropertyDescriptor hookUrlWrite = PropertyUtils.getPropertyDescriptor(
            new GitHubPluginConfig(new ArrayList<>()), "hookUrl"
    );
    assertNotNull("hookUrl write method should exits", hookUrlWrite.getWriteMethod());
}
```

### Testing done

Re-enabled and modernized the test suite regarding global configs.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/376)
<!-- Reviewable:end -->
