### PR TITLE
Replace JSR-305 annotations with spotbugs annotations

### DIFF
--- a/src/main/java/com/coravy/hudson/plugins/github/GithubLinkAnnotator.java
+++ b/src/main/java/com/coravy/hudson/plugins/github/GithubLinkAnnotator.java
@@ -9,9 +9,9 @@ import hudson.scm.ChangeLogAnnotator;
 import hudson.scm.ChangeLogSet.Entry;
 import org.apache.commons.lang.StringUtils;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static hudson.Functions.htmlAttributeEscape;
 import static java.lang.String.format;
@@ -100,13 +100,13 @@ public class GithubLinkAnnotator extends ChangeLogAnnotator {
             "(?:C|c)lose(?:s?)\\s(?<!\\:)(?:#)NUM", // "Closes #123"
             "issues/$1")};
 
-    @Nonnull
+    @NonNull
     public static String getAllowedUriSchemes() {
         return StringUtils.join(ALLOWED_URI_SCHEMES, ',');
     }
 
     @CheckReturnValue
-    @Nonnull
+    @NonNull
     public static boolean verifyUrl(@CheckForNull String urlString) {
         if (StringUtils.isBlank(urlString)) {
             return false;


### PR DESCRIPTION
## Replace JSR-305 annotations with spotbugs annotations

Annotations for Nonnull, CheckForNull, and several others were proposed for Java as part of dormant Java specification request JSR-305. The proposal never became a part of standard Java.

Jenkins plugins should switch from using JSR-305 annotations to use Spotbugs annotations that provide the same semantics.  

The [mailing list discussion](https://groups.google.com/g/jenkinsci-dev/c/uE1wwtVi1W0/m/gLxdEJmlBQAJ) from James Nord describes the affected annotations and why they should be replaced with annotations that are actively maintained.

The ["Improve a plugin" tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/) provides instructions to perform this change.

An [OpenRewrite recipe](https://docs.openrewrite.org/recipes/jenkins/javaxannotationstospotbugs) is also available and is even better than the tutorial.

### Testing done

Confirmed that automated tests pass on Linux with Java 21.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
