### PR TITLE
[JENKINS-73163] Allow users with Overall/Manage permission to configure GitHub Servers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <jenkins.version>2.414.3</jenkins.version>
         <release.skipTests>false</release.skipTests>
         <tagNameFormat>v@{project.version}</tagNameFormat>
+        <useBeta>true</useBeta> <!-- For Jenkins.MANAGE permission -->
     </properties>
 
     <repositories>

--- a/src/main/java/org/jenkinsci/plugins/github/config/GitHubServerConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/github/config/GitHubServerConfig.java
@@ -348,7 +348,7 @@ public class GitHubServerConfig extends AbstractDescribableImpl<GitHubServerConf
         @SuppressWarnings("unused")
         public ListBoxModel doFillCredentialsIdItems(@QueryParameter String apiUrl,
                                                      @QueryParameter String credentialsId) {
-            if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
+            if (!Jenkins.getInstance().hasPermission(Jenkins.MANAGE)) {
                 return new StandardListBoxModel().includeCurrentValue(credentialsId);
             }
             return new StandardListBoxModel()
@@ -367,7 +367,7 @@ public class GitHubServerConfig extends AbstractDescribableImpl<GitHubServerConf
         public FormValidation doVerifyCredentials(
                 @QueryParameter String apiUrl,
                 @QueryParameter String credentialsId) throws IOException {
-            Jenkins.getActiveInstance().checkPermission(Jenkins.ADMINISTER);
+            Jenkins.getActiveInstance().checkPermission(Jenkins.MANAGE);
 
             GitHubServerConfig config = new GitHubServerConfig(credentialsId);
             config.setApiUrl(apiUrl);

--- a/src/main/java/org/jenkinsci/plugins/github/config/HookSecretConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/github/config/HookSecretConfig.java
@@ -62,7 +62,7 @@ public class HookSecretConfig extends AbstractDescribableImpl<HookSecretConfig> 
 
         @SuppressWarnings("unused")
         public ListBoxModel doFillCredentialsIdItems(@QueryParameter String credentialsId) {
-            if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
+            if (!Jenkins.getInstance().hasPermission(Jenkins.MANAGE)) {
                 return new StandardListBoxModel().includeCurrentValue(credentialsId);
             }
 

--- a/src/test/java/org/jenkinsci/plugins/github/config/GitHubServerConfigIntegrationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/config/GitHubServerConfigIntegrationTest.java
@@ -107,7 +107,9 @@ public class GitHubServerConfigIntegrationTest {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
 
         GlobalMatrixAuthorizationStrategy strategy = new GlobalMatrixAuthorizationStrategy();
-        strategy.add(Jenkins.ADMINISTER, "admin");
+        Jenkins.MANAGE.setEnabled(true);
+        strategy.add(Jenkins.MANAGE, "admin");
+        strategy.add(Jenkins.READ, "admin");
         strategy.add(Jenkins.READ, "user");
         j.jenkins.setAuthorizationStrategy(strategy);
         
@@ -121,7 +123,7 @@ public class GitHubServerConfigIntegrationTest {
             
             assertThat(attackerServlet.secretCreds, isEmptyOrNullString());
         }
-        { // only admin can verify the credentials
+        { // only admin (with Manage permission) can verify the credentials
             JenkinsRule.WebClient wc = j.createWebClient();
             wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
             wc.login("admin");


### PR DESCRIPTION
See [JENKINS-73163](https://issues.jenkins.io/browse/JENKINS-73163) for more information.

Some features have been intentionally left out and they will keep requiring `Jenkins.ADMINISTER`. They are administrative monitors and webhook auto-registering.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
