### PR TITLE
[JENKINS-73163] Follow up on Overall/Manage permission support

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github/config/GitHubPluginConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/github/config/GitHubPluginConfig.java
@@ -4,11 +4,13 @@ import com.cloudbees.jenkins.GitHubWebHook;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import hudson.XmlFile;
 import hudson.model.Descriptor;
 import hudson.model.Item;
+import hudson.security.Permission;
 import hudson.util.FormValidation;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
@@ -212,7 +214,7 @@ public class GitHubPluginConfig extends GlobalConfiguration {
     @SuppressWarnings("unused")
     @RequirePOST
     public FormValidation doReRegister() {
-        Jenkins.getActiveInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.getActiveInstance().checkPermission(Jenkins.MANAGE);
         if (!GitHubPlugin.configuration().isManageHooks()) {
             return FormValidation.warning("Works only when Jenkins manages hooks (one or more creds specified)");
         }
@@ -227,7 +229,7 @@ public class GitHubPluginConfig extends GlobalConfiguration {
     @Restricted(DoNotUse.class) // WebOnly
     @SuppressWarnings("unused")
     public FormValidation doCheckHookUrl(@QueryParameter String value) {
-        Jenkins.getActiveInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.getActiveInstance().checkPermission(Jenkins.MANAGE);
         try {
             HttpURLConnection con = (HttpURLConnection) new URL(value).openConnection();
             con.setRequestMethod("POST");
@@ -316,5 +318,11 @@ public class GitHubPluginConfig extends GlobalConfiguration {
         } catch (MalformedURLException e) {
             return null;
         }
+    }
+
+    @NonNull
+    @Override
+    public Permission getRequiredGlobalConfigPagePermission() {
+        return Jenkins.MANAGE;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/github/config/GitHubServerConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/github/config/GitHubServerConfig.java
@@ -14,6 +14,7 @@ import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.security.ACL;
+import hudson.security.Permission;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
@@ -345,6 +346,12 @@ public class GitHubServerConfig extends AbstractDescribableImpl<GitHubServerConf
             return "GitHub Server";
         }
 
+        @NonNull
+        @Override
+        public Permission getRequiredGlobalConfigPagePermission() {
+            return Jenkins.MANAGE;
+        }
+
         @SuppressWarnings("unused")
         public ListBoxModel doFillCredentialsIdItems(@QueryParameter String apiUrl,
                                                      @QueryParameter String credentialsId) {
@@ -419,4 +426,6 @@ public class GitHubServerConfig extends AbstractDescribableImpl<GitHubServerConf
             return github.getCachedClient();
         }
     }
+
+
 }

--- a/src/main/java/org/jenkinsci/plugins/github/config/GitHubTokenCredentialsCreator.java
+++ b/src/main/java/org/jenkinsci/plugins/github/config/GitHubTokenCredentialsCreator.java
@@ -92,7 +92,7 @@ public class GitHubTokenCredentialsCreator extends Descriptor<GitHubTokenCredent
 
     @SuppressWarnings("unused")
     public ListBoxModel doFillCredentialsIdItems(@QueryParameter String apiUrl, @QueryParameter String credentialsId) {
-        if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
+        if (!Jenkins.getInstance().hasPermission(Jenkins.MANAGE)) {
             return new StandardUsernameListBoxModel().includeCurrentValue(credentialsId);
         }
         return new StandardUsernameListBoxModel()
@@ -118,7 +118,7 @@ public class GitHubTokenCredentialsCreator extends Descriptor<GitHubTokenCredent
     public FormValidation doCreateTokenByCredentials(
             @QueryParameter String apiUrl,
             @QueryParameter String credentialsId) {
-        Jenkins.getActiveInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.getActiveInstance().checkPermission(Jenkins.MANAGE);
         if (isEmpty(credentialsId)) {
             return FormValidation.error("Please specify credentials to create token");
         }
@@ -167,7 +167,7 @@ public class GitHubTokenCredentialsCreator extends Descriptor<GitHubTokenCredent
             @QueryParameter String apiUrl,
             @QueryParameter String login,
             @QueryParameter String password) {
-        Jenkins.getActiveInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.getActiveInstance().checkPermission(Jenkins.MANAGE);
         try {
             GHAuthorization token = createToken(login, password, defaultIfBlank(apiUrl, GITHUB_URL));
             StandardCredentials credentials = createCredentials(apiUrl, token.getToken(), login);

--- a/src/main/java/org/jenkinsci/plugins/github/config/HookSecretConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/github/config/HookSecretConfig.java
@@ -3,10 +3,12 @@ package org.jenkinsci.plugins.github.config;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.security.ACL;
+import hudson.security.Permission;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
@@ -75,6 +77,12 @@ public class HookSecretConfig extends AbstractDescribableImpl<HookSecretConfig> 
                             Collections.<DomainRequirement>emptyList(),
                             CredentialsMatchers.always()
                     );
+        }
+
+        @NonNull
+        @Override
+        public Permission getRequiredGlobalConfigPagePermission() {
+            return Jenkins.MANAGE;
         }
     }
 }


### PR DESCRIPTION
In https://github.com/jenkinsci/github-plugin/pull/378 some features were left out, but I see now that they are all part of the same global configuration section. So it does not make sense
to leave them behind. They all require Overall/Manage now (instead of Administer).

I've manually tested that all the configuration is shown in the UI for a user with Overall/Manage.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
