### PR TITLE
JENKINS-72788: Un-inlining JS in GitHubPushTrigger/config.groovy

### DIFF
--- a/src/main/resources/com/cloudbees/jenkins/GitHubPushTrigger/config.groovy
+++ b/src/main/resources/com/cloudbees/jenkins/GitHubPushTrigger/config.groovy
@@ -4,17 +4,14 @@ import com.cloudbees.jenkins.GitHubPushTrigger
 
 tr {
     td(colspan: 4) {
-        div(id: 'gh-hooks-warn')
+        def url = descriptor.getCheckMethod('hookRegistered').toCheckUrl()
+        def input = "input[name='${GitHubPushTrigger.class.getName().replace('.', '-')}']"
+
+        div(id: 'gh-hooks-warn',
+                'data-url': url,
+                'data-input': input
+        )
     }
 }
 
 script(src:"${rootURL}${h.getResourcePath()}/plugin/github/js/warning.js")
-script {
-    text("""
-InlineWarning.setup({ 
-    id: 'gh-hooks-warn',
-    url: ${descriptor.getCheckMethod('hookRegistered').toCheckUrl()}, 
-    input: 'input[name="${GitHubPushTrigger.class.getName().replace(".", "-")}"]'
-}).start();
-""")
-}

--- a/src/main/webapp/js/warning.js
+++ b/src/main/webapp/js/warning.js
@@ -9,6 +9,16 @@ var InlineWarning = (function () {
 
     exports.setup = function (opts) {
         options = opts;
+
+        // Check if the URL needs concatenation
+        if (opts.url.includes("'+'")) {
+            // Manually concatenate the parts
+            let parts = opts.url.split("'+'");
+            options.url = parts.map(part => part.replace(/'/g, '')).join('');
+        } else {
+            options.url = opts.url;
+        }
+
         return exports;
     };
 
@@ -39,3 +49,24 @@ var InlineWarning = (function () {
 
     return exports;
 })();
+
+document.addEventListener('DOMContentLoaded', function() {
+    var warningElement = document.getElementById('gh-hooks-warn');
+
+    if (warningElement) {
+        var url = warningElement.getAttribute('data-url');
+        var input = warningElement.getAttribute('data-input');
+
+        if (url && input) {
+            InlineWarning.setup({
+                id: 'gh-hooks-warn',
+                url: url,
+                input: input
+            }).start();
+        } else {
+            console.error('URL or Input is null');
+        }
+    } else {
+        console.error('Element with ID "gh-hooks-warn" not found');
+    }
+});


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
See [JENKINS-72788](https://issues.jenkins.io/browse/JENKINS-72788?jql=labels%20%3D%20newbie-friendly).

### Testing done
After un-inlining the inline javascript in GitHubPushTrigger/config.groovy, it still can periodically send request to the "checkHookRegistered" endpoint.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
