### PR TITLE
Remove `useBeta` property from `pom.xml`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.2</version>
+        <version>5.5</version>
         <relativePath />
     </parent>
 
@@ -52,10 +52,10 @@
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
         <jenkins.baseline>2.479</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+        <!-- REMOVE -->
+        <jenkins.version>2.494-rc35897.1f8edd4c1651</jenkins.version>
         <release.skipTests>false</release.skipTests>
         <tagNameFormat>v@{project.version}</tagNameFormat>
-        <useBeta>true</useBeta> <!-- For Jenkins.MANAGE permission -->
     </properties>
 
     <repositories>
@@ -64,7 +64,7 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
-    
+
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
         <jenkins.baseline>2.479</jenkins.baseline>
         <!-- REMOVE -->
-        <jenkins.version>2.494-rc35897.1f8edd4c1651</jenkins.version>
+        <jenkins.version>2.495</jenkins.version>
         <release.skipTests>false</release.skipTests>
         <tagNameFormat>v@{project.version}</tagNameFormat>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,8 @@
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.479</jenkins.baseline>
-        <!-- REMOVE -->
-        <jenkins.version>2.495</jenkins.version>
+        <jenkins.baseline>2.504</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
         <release.skipTests>false</release.skipTests>
         <tagNameFormat>v@{project.version}</tagNameFormat>
     </properties>
@@ -201,7 +200,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>3559.vb_5b_81183b_d23</version>
+                <version>4710.v016f0a_07e34d</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
Now that the permission `Jenkins.MANAGE` is out of beta (https://github.com/jenkinsci/jenkins/pull/10183) the `useBeta` property is no longer required.

This is still a draft, since it will take some time until that change is shipped in an LTS and this plugin updates to it.
I would like to use this PR as a reminder and update / merge it once the requirements are met.

### Testing done

Validated with `mvn clean verify`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
