### PR TITLE
Do not use static state variables in Extension class

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github/admin/GitHubDuplicateEventsMonitor.java
+++ b/src/main/java/org/jenkinsci/plugins/github/admin/GitHubDuplicateEventsMonitor.java
@@ -207,7 +207,7 @@ public class GitHubDuplicateEventsMonitor extends AdministrativeMonitor {
          */
         @VisibleForTesting
         @Restricted(NoExternalUse.class)
-        Set<String> getEventCountsTracker() {
+        Set<String> getPresentEventKeys() {
             return eventTracker.asMap().keySet().stream()
                                .filter(key -> eventTracker.getIfPresent(key) != null)
                                .collect(Collectors.toSet());

--- a/src/test/java/org/jenkinsci/plugins/github/admin/GitHubDuplicateEventsMonitorUnitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/admin/GitHubDuplicateEventsMonitorUnitTest.java
@@ -32,21 +32,21 @@ public class GitHubDuplicateEventsMonitorUnitTest {
         assertThat("should not throw NPE", subscriber.isDuplicateEventSeen(), is(false));
         // send a null event
         subscriber.onEvent(new GHSubscriberEvent(null, "origin", GHEvent.PUSH, "payload"));
-        assertThat("null event is not tracked", subscriber.getEventCountsTracker().size(), is(0));
+        assertThat("null event is not tracked", subscriber.getPresentEventKeys().size(), is(0));
         assertThat("lastDuplicate is still null", subscriber.getLastDuplicate(), is(nullValue()));
 
         // at present
         subscriber.onEvent(new GHSubscriberEvent("1", "origin", GHEvent.PUSH, "payload"));
-        assertThat(subscriber.getEventCountsTracker(), is(Set.of("1")));
+        assertThat(subscriber.getPresentEventKeys(), is(Set.of("1")));
         assertThat(subscriber.getLastDuplicate(), is(nullValue()));
         assertThat(subscriber.isDuplicateEventSeen(), is(false));
         subscriber.onEvent(new GHSubscriberEvent("2", "origin", GHEvent.PUSH, "payload"));
         assertThat(subscriber.getLastDuplicate(), is(nullValue()));
         assertThat(subscriber.isDuplicateEventSeen(), is(false));
-        assertThat(subscriber.getEventCountsTracker(), is(Set.of("1", "2")));
+        assertThat(subscriber.getPresentEventKeys(), is(Set.of("1", "2")));
         subscriber.onEvent(new GHSubscriberEvent(null, "origin", GHEvent.PUSH, "payload"));
         assertThat(subscriber.getLastDuplicate(), is(nullValue()));
-        assertThat(subscriber.getEventCountsTracker(), is(Set.of("1", "2")));
+        assertThat(subscriber.getPresentEventKeys(), is(Set.of("1", "2")));
         assertThat(subscriber.isDuplicateEventSeen(), is(false));
 
         // after a second
@@ -54,7 +54,7 @@ public class GitHubDuplicateEventsMonitorUnitTest {
         subscriber.onEvent(new GHSubscriberEvent("1", "origin", GHEvent.PUSH, "payload"));
         assertThat(subscriber.getLastDuplicate().eventGuid(), is("1"));
         assertThat(subscriber.getLastDuplicate().lastUpdated(), is(after1Sec));
-        assertThat(subscriber.getEventCountsTracker(), is(Set.of("1", "2")));
+        assertThat(subscriber.getPresentEventKeys(), is(Set.of("1", "2")));
         assertThat(subscriber.isDuplicateEventSeen(), is(true));
 
         // second occurrence for another event after 2 seconds
@@ -62,7 +62,7 @@ public class GitHubDuplicateEventsMonitorUnitTest {
         subscriber.onEvent(new GHSubscriberEvent("2", "origin", GHEvent.PUSH, "payload"));
         assertThat(subscriber.getLastDuplicate().eventGuid(), is("2"));
         assertThat(subscriber.getLastDuplicate().lastUpdated(), is(after2Sec));
-        assertThat(subscriber.getEventCountsTracker(), is(Set.of("1", "2")));
+        assertThat(subscriber.getPresentEventKeys(), is(Set.of("1", "2")));
         assertThat(subscriber.isDuplicateEventSeen(), is(true));
 
         // 24 hours has passed; note we already added 2 seconds/ so effectively 24h 2sec now.
@@ -81,19 +81,19 @@ public class GitHubDuplicateEventsMonitorUnitTest {
         // at present
         subscriber.onEvent(new GHSubscriberEvent("1", "origin", GHEvent.PUSH, "payload"));
         subscriber.onEvent(new GHSubscriberEvent("2", "origin", GHEvent.PUSH, "payload"));
-        assertThat(subscriber.getEventCountsTracker(), is(Set.of("1", "2")));
+        assertThat(subscriber.getPresentEventKeys(), is(Set.of("1", "2")));
 
         // after 2 minutes
         fakeTicker.advance(Duration.ofMinutes(2));
         subscriber.onEvent(new GHSubscriberEvent("3", "origin", GHEvent.PUSH, "payload"));
         subscriber.onEvent(new GHSubscriberEvent("4", "origin", GHEvent.PUSH, "payload"));
-        assertThat(subscriber.getEventCountsTracker(), is(Set.of("1", "2", "3", "4")));
-        assertThat(subscriber.getEventCountsTracker().size(), is(4));
+        assertThat(subscriber.getPresentEventKeys(), is(Set.of("1", "2", "3", "4")));
+        assertThat(subscriber.getPresentEventKeys().size(), is(4));
 
         // 10 minutes 1 second later
         fakeTicker.advance(Duration.ofMinutes(8).plusSeconds(1));
-        assertThat(subscriber.getEventCountsTracker(), is(Set.of("3", "4")));
-        assertThat(subscriber.getEventCountsTracker().size(), is(2));
+        assertThat(subscriber.getPresentEventKeys(), is(Set.of("3", "4")));
+        assertThat(subscriber.getPresentEventKeys().size(), is(2));
     }
 
     private static class FakeTicker implements Ticker {

--- a/src/test/java/org/jenkinsci/plugins/github/admin/GitHubDuplicateEventsMonitorUnitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/admin/GitHubDuplicateEventsMonitorUnitTest.java
@@ -3,9 +3,6 @@ package org.jenkinsci.plugins.github.admin;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.jenkinsci.plugins.github.admin.GitHubDuplicateEventsMonitor.DuplicateEventsSubscriber.getEventCountsTracker;
-import static org.jenkinsci.plugins.github.admin.GitHubDuplicateEventsMonitor.DuplicateEventsSubscriber.getLastDuplicate;
-import static org.jenkinsci.plugins.github.admin.GitHubDuplicateEventsMonitor.DuplicateEventsSubscriber.isDuplicateEventSeen;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -21,81 +18,82 @@ import org.kohsuke.github.GHEvent;
 @For(GitHubDuplicateEventsMonitor.DuplicateEventsSubscriber.class)
 public class GitHubDuplicateEventsMonitorUnitTest {
 
-    private final GitHubDuplicateEventsMonitor.DuplicateEventsSubscriber subscriber
-        = new GitHubDuplicateEventsMonitor.DuplicateEventsSubscriber();
-
     @Test
     public void onEventShouldTrackEventAndKeepTrackOfLastDuplicate() {
+        var subscriber = new GitHubDuplicateEventsMonitor.DuplicateEventsSubscriber();
+
         var now = Instant.parse("2025-02-05T03:00:00Z");
         var after1Sec = Instant.parse("2025-02-05T03:00:01Z");
         var after2Sec = Instant.parse("2025-02-05T03:00:02Z");
         FakeTicker fakeTicker = new FakeTicker(now);
-        GitHubDuplicateEventsMonitor.DuplicateEventsSubscriber.setTicker(fakeTicker);
+        subscriber.setTicker(fakeTicker);
 
-        assertThat("lastDuplicate is null at first", getLastDuplicate(), is(nullValue()));
-        assertThat("should not throw NPE", isDuplicateEventSeen(), is(false));
+        assertThat("lastDuplicate is null at first", subscriber.getLastDuplicate(), is(nullValue()));
+        assertThat("should not throw NPE", subscriber.isDuplicateEventSeen(), is(false));
         // send a null event
         subscriber.onEvent(new GHSubscriberEvent(null, "origin", GHEvent.PUSH, "payload"));
-        assertThat("null event is not tracked", getEventCountsTracker().size(), is(0));
-        assertThat("lastDuplicate is still null", getLastDuplicate(), is(nullValue()));
+        assertThat("null event is not tracked", subscriber.getEventCountsTracker().size(), is(0));
+        assertThat("lastDuplicate is still null", subscriber.getLastDuplicate(), is(nullValue()));
 
         // at present
         subscriber.onEvent(new GHSubscriberEvent("1", "origin", GHEvent.PUSH, "payload"));
-        assertThat(getEventCountsTracker(), is(Set.of("1")));
-        assertThat(getLastDuplicate(), is(nullValue()));
-        assertThat(isDuplicateEventSeen(), is(false));
+        assertThat(subscriber.getEventCountsTracker(), is(Set.of("1")));
+        assertThat(subscriber.getLastDuplicate(), is(nullValue()));
+        assertThat(subscriber.isDuplicateEventSeen(), is(false));
         subscriber.onEvent(new GHSubscriberEvent("2", "origin", GHEvent.PUSH, "payload"));
-        assertThat(getLastDuplicate(), is(nullValue()));
-        assertThat(isDuplicateEventSeen(), is(false));
-        assertThat(getEventCountsTracker(), is(Set.of("1", "2")));
+        assertThat(subscriber.getLastDuplicate(), is(nullValue()));
+        assertThat(subscriber.isDuplicateEventSeen(), is(false));
+        assertThat(subscriber.getEventCountsTracker(), is(Set.of("1", "2")));
         subscriber.onEvent(new GHSubscriberEvent(null, "origin", GHEvent.PUSH, "payload"));
-        assertThat(getLastDuplicate(), is(nullValue()));
-        assertThat(getEventCountsTracker(), is(Set.of("1", "2")));
-        assertThat(isDuplicateEventSeen(), is(false));
+        assertThat(subscriber.getLastDuplicate(), is(nullValue()));
+        assertThat(subscriber.getEventCountsTracker(), is(Set.of("1", "2")));
+        assertThat(subscriber.isDuplicateEventSeen(), is(false));
 
         // after a second
         fakeTicker.advance(Duration.ofSeconds(1));
         subscriber.onEvent(new GHSubscriberEvent("1", "origin", GHEvent.PUSH, "payload"));
-        assertThat(getLastDuplicate().eventGuid(), is("1"));
-        assertThat(getLastDuplicate().lastUpdated(), is(after1Sec));
-        assertThat(getEventCountsTracker(), is(Set.of("1", "2")));
-        assertThat(isDuplicateEventSeen(), is(true));
+        assertThat(subscriber.getLastDuplicate().eventGuid(), is("1"));
+        assertThat(subscriber.getLastDuplicate().lastUpdated(), is(after1Sec));
+        assertThat(subscriber.getEventCountsTracker(), is(Set.of("1", "2")));
+        assertThat(subscriber.isDuplicateEventSeen(), is(true));
 
         // second occurrence for another event after 2 seconds
         fakeTicker.advance(Duration.ofSeconds(1));
         subscriber.onEvent(new GHSubscriberEvent("2", "origin", GHEvent.PUSH, "payload"));
-        assertThat(getLastDuplicate().eventGuid(), is("2"));
-        assertThat(getLastDuplicate().lastUpdated(), is(after2Sec));
-        assertThat(getEventCountsTracker(), is(Set.of("1", "2")));
-        assertThat(isDuplicateEventSeen(), is(true));
+        assertThat(subscriber.getLastDuplicate().eventGuid(), is("2"));
+        assertThat(subscriber.getLastDuplicate().lastUpdated(), is(after2Sec));
+        assertThat(subscriber.getEventCountsTracker(), is(Set.of("1", "2")));
+        assertThat(subscriber.isDuplicateEventSeen(), is(true));
 
         // 24 hours has passed; note we already added 2 seconds/ so effectively 24h 2sec now.
         fakeTicker.advance(Duration.ofHours(24));
-        assertThat(isDuplicateEventSeen(), is(false));
+        assertThat(subscriber.isDuplicateEventSeen(), is(false));
     }
 
     @Test
     public void checkOldEntriesAreExpiredAfter10Minutes() {
+        var subscriber = new GitHubDuplicateEventsMonitor.DuplicateEventsSubscriber();
+
         var now = Instant.parse("2025-02-05T03:00:00Z");
         FakeTicker fakeTicker = new FakeTicker(now);
-        GitHubDuplicateEventsMonitor.DuplicateEventsSubscriber.setTicker(fakeTicker);
+        subscriber.setTicker(fakeTicker);
 
         // at present
         subscriber.onEvent(new GHSubscriberEvent("1", "origin", GHEvent.PUSH, "payload"));
         subscriber.onEvent(new GHSubscriberEvent("2", "origin", GHEvent.PUSH, "payload"));
-        assertThat(getEventCountsTracker(), is(Set.of("1", "2")));
+        assertThat(subscriber.getEventCountsTracker(), is(Set.of("1", "2")));
 
         // after 2 minutes
         fakeTicker.advance(Duration.ofMinutes(2));
         subscriber.onEvent(new GHSubscriberEvent("3", "origin", GHEvent.PUSH, "payload"));
         subscriber.onEvent(new GHSubscriberEvent("4", "origin", GHEvent.PUSH, "payload"));
-        assertThat(getEventCountsTracker(), is(Set.of("1", "2", "3", "4")));
-        assertThat(getEventCountsTracker().size(), is(4));
+        assertThat(subscriber.getEventCountsTracker(), is(Set.of("1", "2", "3", "4")));
+        assertThat(subscriber.getEventCountsTracker().size(), is(4));
 
         // 10 minutes 1 second later
         fakeTicker.advance(Duration.ofMinutes(8).plusSeconds(1));
-        assertThat(getEventCountsTracker(), is(Set.of("3", "4")));
-        assertThat(getEventCountsTracker().size(), is(2));
+        assertThat(subscriber.getEventCountsTracker(), is(Set.of("3", "4")));
+        assertThat(subscriber.getEventCountsTracker().size(), is(2));
     }
 
     private static class FakeTicker implements Ticker {


### PR DESCRIPTION
Flakiness in the test was identified (possibly) due to the use of static stateful fields in the `@Extension` class. See [this comment](https://github.com/jenkinsci/github-plugin/pull/388#issuecomment-2672968464) for details. Issue was likely parallel test execution mutating the state of static field.

This PR addresses the issue following the [comment here](https://github.com/jenkinsci/github-plugin/pull/388#issuecomment-2679138087).

Note: This problem only affects tests and does not impact Jenkins functionality. Whether the data is stored in a static cache or within a field inside a singleton instance, it effectively centralizes event data in one place.

### Testing done
* Automated tests still executing correctly.
* Manual testing
   * verify the duplicate events monitor functionality is correct as before (tested by sending duplicate events - admin monitor comes, restart jenkins - monitor goes away)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
