### PR TITLE
Convert tests to `com.sun.net.httpserver`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.2</version>
+        <version>5.9</version>
         <relativePath />
     </parent>
 
@@ -39,7 +39,7 @@
         <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
         <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
         <url>https://github.com/${gitHubRepo}</url>
-        <tag>v1.42.0</tag>
+        <tag>${scmTag}</tag>
     </scm>
     <issueManagement>
         <system>JIRA</system>
@@ -52,7 +52,7 @@
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
         <jenkins.baseline>2.479</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <release.skipTests>false</release.skipTests>
         <tagNameFormat>v@{project.version}</tagNameFormat>
         <useBeta>true</useBeta> <!-- For Jenkins.MANAGE permission -->
@@ -206,7 +206,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>3559.vb_5b_81183b_d23</version>
+                <version>4488.v7fe26526366e</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/java/org/jenkinsci/plugins/github/internal/GitHubClientCacheOps.java
+++ b/src/main/java/org/jenkinsci/plugins/github/internal/GitHubClientCacheOps.java
@@ -5,7 +5,6 @@ import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.hash.Hashing;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import okhttp3.Cache;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.github.GitHubPlugin;
@@ -96,7 +95,6 @@ public final class GitHubClientCacheOps {
      *
      * @param configs active server configs to exclude caches from cleanup
      */
-    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     public static void clearRedundantCaches(List<GitHubServerConfig> configs) {
         Path baseCacheDir = getBaseCacheDir();
 

--- a/src/test/java/org/jenkinsci/plugins/github/config/GitHubServerConfigIntegrationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/config/GitHubServerConfigIntegrationTest.java
@@ -5,18 +5,16 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.domains.Domain;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import net.sf.json.JSONObject;
 import org.htmlunit.HttpMethod;
 import org.htmlunit.Page;
 import org.htmlunit.WebRequest;
 import hudson.security.GlobalMatrixAuthorizationStrategy;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
-import net.sf.json.JSONObject;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.ee9.servlet.DefaultServlet;
-import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
-import org.eclipse.jetty.ee9.servlet.ServletHolder;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import org.junit.After;
 import org.junit.Before;
@@ -26,10 +24,13 @@ import org.jvnet.hudson.test.For;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -46,7 +47,7 @@ public class GitHubServerConfigIntegrationTest {
     @Rule
     public JenkinsRule j = new JenkinsRule();
     
-    private Server server;
+    private HttpServer server;
     private AttackerServlet attackerServlet;
     private String attackerUrl;
     
@@ -57,35 +58,16 @@ public class GitHubServerConfigIntegrationTest {
     
     @After
     public void stopServer() {
-        try {
-            server.stop();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        server.stop(1);
     }
     
     private void setupAttackerServer() throws Exception {
-        this.server = new Server();
-        ServerConnector serverConnector = new ServerConnector(this.server);
-        server.addConnector(serverConnector);
-        
-        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
-        context.setContextPath("/*");
-        
+        this.server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
         this.attackerServlet = new AttackerServlet();
-        ServletHolder servletHolder = new ServletHolder(attackerServlet);
-        context.addServlet(servletHolder, "/*");
-        
-        server.setHandler(context);
-        
-        server.start();
-        
-        String host = serverConnector.getHost();
-        if (host == null) {
-            host = "localhost";
-        }
-        
-        this.attackerUrl = "http://" + host + ":" + serverConnector.getLocalPort();
+        this.server.createContext("/user", this.attackerServlet);
+        this.server.start();
+        InetSocketAddress addr = this.server.getAddress();
+        this.attackerUrl = String.format("http://%s:%d", addr.getHostString(), addr.getPort());
     }
     
     @Test
@@ -153,25 +135,30 @@ public class GitHubServerConfigIntegrationTest {
         store.addCredentials(domain, credentials);
     }
     
-    private static class AttackerServlet extends DefaultServlet {
+    private static class AttackerServlet implements HttpHandler {
         public String secretCreds;
         
         @Override
-        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-            switch (request.getRequestURI()) {
-                case "/user":
-                    this.onUser(request, response);
-                    break;
+        public void handle(HttpExchange he) throws IOException {
+            if ("GET".equals(he.getRequestMethod())) {
+                this.onUser(he);
+            } else {
+                he.sendResponseHeaders(HttpURLConnection.HTTP_BAD_METHOD, -1);
             }
         }
         
-        private void onUser(HttpServletRequest request, HttpServletResponse response) throws IOException {
-            secretCreds = request.getHeader("Authorization");
-            response.getWriter().write(JSONObject.fromObject(
+        private void onUser(HttpExchange he) throws IOException {
+            secretCreds = he.getRequestHeaders().getFirst("Authorization");
+            String response = JSONObject.fromObject(
                     new HashMap<String, Object>() {{
                         put("login", "alice");
                     }}
-            ).toString());
+            ).toString();
+            byte[] body = response.getBytes(StandardCharsets.UTF_8);
+            he.sendResponseHeaders(HttpURLConnection.HTTP_OK, body.length);
+            try (OutputStream os = he.getResponseBody()) {
+                os.write(body);
+            }
         }
     }
 }


### PR DESCRIPTION
When testing this plugin against EE 10, I found the same test-only (not production) issues in `GitHubServerConfigIntegrationTest` as I did when testing this plugin against EE 9. Rather than continue to adapt this test for every EE version, this PR removes any references to Jetty or Jakarta EE from the test, making the test less fragile. In their place, we substitute references to standard Java Platform functionality.

### Testing done

`mvn clean verify` with Java 21

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
