### PR TITLE
docs(contrib): use consistent bullets and indentation for IDE section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,32 +98,32 @@ To the greatest extent possible, please wrap lines to ensure that they do not ex
 
 ### IDE Configuration
 
-* Eclipse, by and large the IDE defaults are acceptable with the following changes:
-    - Tab policy to `Spaces only`.
-    - Indent statements within `switch` body.
-    - Maximum line width `120`.
-    - Line wrapping, ensure all to `wrap where necessary`.
-    - Organize imports alphabetically, no grouping.
-* NetBeans, by and large the IDE defaults are acceptable with the following changes:
-    - Tabs and Indents:
-        + Change Right Margin to `120`.
-        + Indent case statements in switch.
-    - Wrapping:
-        + Change all the `Never` values to `If Long`.
-        + Select the checkbox for Wrap After Assignment Operators.
-* IntelliJ, by and large the IDE defaults are acceptable with the following changes:
-    - Wrapping and Braces:
-        + Change `Do not wrap` to `Wrap if long`.
-        + Change `Do not force` to `Always`.
-    - Javadoc:
-        + Disable generating `<p/>` on empty lines.
-    - Imports:
-        + Class count to use import with '*': `9999`.
-        + Names count to use static import with '*': `99999`.
-        + Import Layout:
-            * import all other imports.
-            * blank line.
-            * import static all other imports.
+- Eclipse: by and large the IDE defaults are acceptable with the following changes:
+  - Tab policy to `Spaces only`.
+  - Indent statements within `switch` body.
+  - Maximum line width `120`.
+  - Line wrapping, ensure all to `wrap where necessary`.
+  - Organize imports alphabetically, no grouping.
+- NetBeans: by and large the IDE defaults are acceptable with the following changes:
+  - Tabs and Indents:
+    - Change Right Margin to `120`.
+    - Indent case statements in switch.
+  - Wrapping:
+    - Change all the `Never` values to `If Long`.
+    - Select the checkbox for Wrap After Assignment Operators.
+- IntelliJ: by and large the IDE defaults are acceptable with the following changes:
+  - Wrapping and Braces:
+    - Change `Do not wrap` to `Wrap if long`.
+    - Change `Do not force` to `Always`.
+  - Javadoc:
+    - Disable generating `<p/>` on empty lines.
+  - Imports:
+    - Class count to use import with '*': `9999`.
+    - Names count to use static import with '*': `99999`.
+      - Import Layout:
+        - import all other imports.
+        - blank line.
+        - import static all other imports.
 
 ## Issues
 


### PR DESCRIPTION
## Summary

Fix `markdownlint` issues in the "IDE Configuration" section of the `CONTRIBUTING.md` regarding the bullet style

## Details

- per `markdownlint`, use one bullet style and indentation consistently
  - previously used `-`, `*`, and `+`, should only use one (I chose `-`)
  - previously used both two space and four space indents for sub-bullets, should use one consistently (I chose two space)
  - same as my other PR #402, but this one is specific to one section and with almost no other grammatical or style changes

- colon (":") instead of comma (",") for each IDE

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

- `markdownlint` no longer errors for these lines
- See the [rendered markdown rich diff for this PR]()

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [n/a] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
