### PR TITLE
[JENKINS-75544] fix(webhook): use `repo.html_url` instead of `repo.url`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventSubscriber.java
+++ b/src/main/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventSubscriber.java
@@ -113,7 +113,7 @@ public class DefaultPushGHEventSubscriber extends GHEventsSubscriber {
             }
 
         } else {
-            LOGGER.warn("Malformed repo url {}", repoUrl);
+            LOGGER.warn("Malformed repo html url {}", htmlUrl);
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventSubscriber.java
+++ b/src/main/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventSubscriber.java
@@ -73,25 +73,10 @@ public class DefaultPushGHEventSubscriber extends GHEventsSubscriber {
             LOGGER.warn("Received malformed PushEvent: " + event.getPayload(), e);
             return;
         }
-        URL repoUrl = push.getRepository().getUrl();
+        URL htmlUrl = push.getRepository().getHtmlUrl();
         final String pusherName = push.getPusher().getName();
-        LOGGER.info("Received PushEvent for {} from {}", repoUrl, event.getOrigin());
-        GitHubRepositoryName fromEventRepository = GitHubRepositoryName.create(repoUrl.toExternalForm());
-
-        if (fromEventRepository == null) {
-            // On push event on github.com url === html_url
-            // this is not consistent with the API docs and with hosted repositories
-            // see https://goo.gl/c1qmY7
-            // let's retry with 'html_url'
-            URL htmlUrl = push.getRepository().getHtmlUrl();
-            fromEventRepository = GitHubRepositoryName.create(htmlUrl.toExternalForm());
-            if (fromEventRepository != null) {
-                LOGGER.debug("PushEvent handling: 'html_url' field "
-                        + "has been used to retrieve project information (instead of default 'url' field)");
-            }
-        }
-
-        final GitHubRepositoryName changedRepository = fromEventRepository;
+        LOGGER.info("Received PushEvent for {} from {}", htmlUrl, event.getOrigin());
+        final GitHubRepositoryName changedRepository = GitHubRepositoryName.create(htmlUrl.toExternalForm());
 
         if (changedRepository != null) {
             // run in high privilege to see all the projects anonymous users don't see.

--- a/src/test/resources/com/cloudbees/jenkins/GitHubWebHookFullTest/payloads/push.json
+++ b/src/test/resources/com/cloudbees/jenkins/GitHubWebHookFullTest/payloads/push.json
@@ -65,7 +65,7 @@
         "html_url": "https://github.com/lanwen/test",
         "description": "Personal blog",
         "fork": false,
-        "url": "https://github.com/lanwen/test",
+        "url": "https://api.github.com/lanwen/test",
         "forks_url": "https://api.github.com/repos/lanwen/test/forks",
         "keys_url": "https://api.github.com/repos/lanwen/test/keys{/key_id}",
         "collaborators_url": "https://api.github.com/repos/lanwen/test/collaborators{/collaborator}",


### PR DESCRIPTION
## Summary

Per https://github.blog/changelog/2025-04-07-changes-to-the-repository-object-in-push-webhook/, GitHub now gives an API URL in the push webhook's payload for `repo.url`, so the code should be adjusted to handle this

## Details

- update the test payload to modify `repo.url` to be an API URL
- switch the code to instead use `repo.html_url`
  - previously https://github.com/jenkinsci/github-plugin/pull/212 added `repo.html_url` as a fallback; I'm not sure why the fallback wasn't working exactly, but it should now _always_ use `repo.html_url`
  
### Misc Notes / backstory

I stumbled upon this via [a question I happened to see on Stack Overflow's Staging Ground](https://stackoverflow.com/staging-ground/79579500), which I suspected was a bug (and not something the asker could fix) due to the recent breaking change from GitHub. I was able to find an [existing JIRA issue](https://issues.jenkins.io/browse/JENKINS-75544) on the problem and so [answered the question](https://stackoverflow.com/a/79580049/3431180) by linking to ticket.
Seemed like a straightforward fix, so I decided to take a look myself after I saw it hadn't received a fix in a week or so.
I'm otherwise a first-time Jenkins contributor, just coincidentally stumbled upon this

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

- modified the test payload to account for GitHub's changes

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
