### PR TITLE
Add the ability to ignore push events from certain users

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubPushTrigger.java
@@ -35,6 +35,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.Stapler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,8 +68,54 @@ import static org.jenkinsci.plugins.github.util.JobInfoHelpers.asParameterizedJo
  */
 public class GitHubPushTrigger extends Trigger<Job<?, ?>> implements GitHubTrigger {
 
+    private String ignoredUsers;
+
     @DataBoundConstructor
     public GitHubPushTrigger() {
+    }
+
+    /**
+     * Gets the newline-separated list of usernames to ignore.
+     *
+     * @return the ignored users list, or null if not configured
+     * @since FIXME
+     */
+    public String getIgnoredUsers() {
+        return ignoredUsers;
+    }
+
+    /**
+     * Sets the newline-separated list of usernames whose push events should be ignored.
+     * The list will be trimmed of leading/trailing whitespace.
+     *
+     * @param ignoredUsers the newline-separated list of usernames to ignore
+     * @since FIXME
+     */
+    @DataBoundSetter
+    public void setIgnoredUsers(String ignoredUsers) {
+        this.ignoredUsers = Util.fixEmptyAndTrim(ignoredUsers);
+    }
+
+    /**
+     * Checks if the given username should be ignored.
+     * Username comparison is case-insensitive.
+     *
+     * @param username the username to check
+     * @return true if the user should be ignored, false otherwise
+     * @since FIXME
+     */
+    public boolean isUserIgnored(String username) {
+        if (isEmpty(ignoredUsers) || isEmpty(username)) {
+            return false;
+        }
+        String[] ignoredUserArray = ignoredUsers.split("[\\r\\n]+");
+        for (String ignoredUser : ignoredUserArray) {
+            String trimmedUser = ignoredUser.trim();
+            if (!trimmedUser.isEmpty() && trimmedUser.equalsIgnoreCase(username)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventSubscriber.java
+++ b/src/main/java/org/jenkinsci/plugins/github/webhook/subscriber/DefaultPushGHEventSubscriber.java
@@ -92,13 +92,18 @@ public class DefaultPushGHEventSubscriber extends GHEventsSubscriber {
                             LOGGER.debug("Considering to poke {}", fullDisplayName);
                             if (GitHubRepositoryNameContributor.parseAssociatedNames(job)
                                     .contains(changedRepository)) {
-                                LOGGER.info("Poked {}", fullDisplayName);
-                                trigger.onPost(GitHubTriggerEvent.create()
-                                        .withTimestamp(event.getTimestamp())
-                                        .withOrigin(event.getOrigin())
-                                        .withTriggeredByUser(pusherName)
-                                        .build()
-                                );
+                                if (trigger.isUserIgnored(pusherName)) {
+                                    LOGGER.debug("Skipped {} because pusher '{}' is in the ignored users list",
+                                            fullDisplayName, pusherName);
+                                } else {
+                                    LOGGER.info("Poked {}", fullDisplayName);
+                                    trigger.onPost(GitHubTriggerEvent.create()
+                                            .withTimestamp(event.getTimestamp())
+                                            .withOrigin(event.getOrigin())
+                                            .withTriggeredByUser(pusherName)
+                                            .build()
+                                    );
+                                }
                             } else {
                                 LOGGER.debug("Skipped {} because it doesn't have a matching repository.",
                                         fullDisplayName);

--- a/src/main/resources/com/cloudbees/jenkins/GitHubPushTrigger/config.groovy
+++ b/src/main/resources/com/cloudbees/jenkins/GitHubPushTrigger/config.groovy
@@ -2,6 +2,14 @@ package com.cloudbees.jenkins.GitHubPushTrigger
 
 import com.cloudbees.jenkins.GitHubPushTrigger
 
+def f = namespace(lib.FormTagLib)
+
+f.advanced() {
+    f.entry(title: _('Ignored Users'), field: 'ignoredUsers') {
+        f.textarea()
+    }
+}
+
 tr {
     td(colspan: 4) {
         def url = descriptor.getCheckMethod('hookRegistered').toCheckUrl()

--- a/src/main/resources/com/cloudbees/jenkins/GitHubPushTrigger/help-ignoredUsers.html
+++ b/src/main/resources/com/cloudbees/jenkins/GitHubPushTrigger/help-ignoredUsers.html
@@ -1,0 +1,11 @@
+<div>
+    A newline-separated list of (case-insensitive) GitHub usernames whose push events should be ignored.
+    <br/>
+    When a push event is received from a user in this list, the trigger will not poll for changes.
+    <br/>
+    <br/>
+    Example:
+    <pre>renovate-bot
+dependabot[bot]
+some-automation-user</pre>
+</div>

--- a/src/test/java/com/cloudbees/jenkins/GitHubPushTriggerTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GitHubPushTriggerTest.java
@@ -26,6 +26,8 @@ import static com.cloudbees.jenkins.GitHubWebHookFullTest.classpath;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.jenkinsci.plugins.github.webhook.subscriber.DefaultPushGHEventListenerTest.TRIGGERED_BY_USER_FROM_RESOURCE;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author lanwen (Merkushev Kirill)
@@ -96,5 +98,40 @@ class GitHubPushTriggerTest {
 
         FormValidation validation = descriptor.doCheckHookRegistered(job);
         assertThat("all ok", validation.kind, is(FormValidation.Kind.OK));
+    }
+
+    @Test
+    public void shouldIgnoreSingleUser() {
+        GitHubPushTrigger trigger = new GitHubPushTrigger();
+        trigger.setIgnoredUsers("ignored-user");
+
+        assertTrue("user should be ignored", trigger.isUserIgnored("ignored-user"));
+        assertTrue("user should be ignored", trigger.isUserIgnored("IGNORED-user"));
+        assertFalse("user should not be ignored", trigger.isUserIgnored("another-user"));
+        assertFalse("user should not be ignored", trigger.isUserIgnored(""));
+        assertFalse("user should not be ignored", trigger.isUserIgnored(null));
+    }
+
+    @Test
+    public void shouldIgnoreMultipleUsers() {
+        GitHubPushTrigger trigger = new GitHubPushTrigger();
+        trigger.setIgnoredUsers(" user1 \nUsEr2\nuser3");
+
+        assertTrue("user should be ignored", trigger.isUserIgnored("user1"));
+        assertTrue("user should be ignored", trigger.isUserIgnored("user2"));
+        assertTrue("user should be ignored", trigger.isUserIgnored("USER3"));
+        assertFalse("user should not be ignored", trigger.isUserIgnored("user4"));
+        assertFalse("user should not be ignored", trigger.isUserIgnored(""));
+        assertFalse("user should not be ignored", trigger.isUserIgnored(null));
+    }
+
+    @Test
+    public void shouldHandleEmptyIgnoredUsers() {
+        GitHubPushTrigger trigger = new GitHubPushTrigger();
+        trigger.setIgnoredUsers("");
+
+        assertFalse("user should not be ignored", trigger.isUserIgnored("user4"));
+        assertFalse("user should not be ignored", trigger.isUserIgnored(""));
+        assertFalse("user should not be ignored", trigger.isUserIgnored(null));
     }
 }


### PR DESCRIPTION
This adds the ability to specify (per-job) usernames that should be ignored when determining whether or not to trigger a git poll from a GitHub webhook event.

This addresses [JENKINS-48139](https://issues.jenkins.io/browse/JENKINS-48139) and [JENKINS-24208](https://issues.jenkins.io/browse/JENKINS-24208)

There have been a handful of PRs that have tried to fix this or similar issues (https://github.com/jenkinsci/github-plugin/pull/58, https://github.com/jenkinsci/github-plugin/pull/182, https://github.com/jenkinsci/github-plugin/pull/83). They have either been closed or abandoned (afaict).

### Testing done

Added testcases in `GitHubPushTriggerTest.java` and `DefaultPushGHEventListenerTest.java`

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/448)
<!-- Reviewable:end -->
