### PR TITLE
Pin groovy to 4.0.29 to fix Java 25 CPS pipeline test failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,17 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- rest-assured:5.3.2 transitively pulls in groovy:4.0.11, which bundles ASM 9.5.
+             ASM 9.5 cannot read Java 25 compiled class files (major version 69), causing CPS
+             pipeline tests to fail at runtime. Pinning to 4.0.29 (ASM 9.9) fixes this.
+             Groovy 5.x cannot be used here as it is incompatible with groovy-cps. -->
+        <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>4.0.29</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <dependencyManagement>


### PR DESCRIPTION
## What is this PR trying to fix
- running PCT tests in a Java 25 environment , cases error

## Summary

- `rest-assured:5.3.2` transitively pulls in `groovy:4.0.11`, which bundles ASM 9.5
- ASM 9.5 cannot read Java 25 compiled class files (major version 69), causing `GitHubPushTriggerTest#shouldStartWorkflowByTrigger` and `DefaultPushGHEventListenerTest#shouldReceivePushHookOnWorkflow` to fail at runtime during CPS pipeline execution
- error 
See [CloudBees-internal reference](https://cloudbees.atlassian.net/browse/BEE-71990) for full root cause analysis.

```
[ERROR]   DefaultPushGHEventListenerTest.shouldReceivePushHookOnWorkflow:113 unexpected build status; build log was:
------
Started
java.lang.IllegalArgumentException: Unsupported class file major version 69
	at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:199)
	at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:180)
	at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:166)
	at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:287)
	at org.codehaus.groovy.ast.decompiled.AsmDecompiler.parseClass(AsmDecompiler.java:83)
	at org.codehaus.groovy.control.ClassNodeResolver.findDecompiled(ClassNodeResolver.java:255)
	at org.codehaus.groovy.control.ClassNodeResolver.tryAsLoaderClassOrScript(ClassNodeResolver.java:193)
	at org.codehaus.groovy.control.ClassNodeResolver.findClassNode(ClassNodeResolver.java:175)
	at org.codehaus.groovy.control.ClassNodeResolver.resolveName(ClassNodeResolver.java:129)
	at org.codehaus.groovy.ast.decompiled.AsmReferenceResolver.resolveClassNullable(AsmReferenceResolver.java:57)
	at org.codehaus.groovy.ast.decompiled.AsmReferenceResolver.resolveClass(AsmReferenceResolver.java:44)
	at org.codehaus.groovy.ast.decompiled.ClassSignatureParser.configureClass(ClassSignatureParser.java:48)
	at org.codehaus.groovy.ast.decompiled.DecompiledClassNode.lazyInitSupers(DecompiledClassNode.java:189)
	at org.codehaus.groovy.ast.decompiled.DecompiledClassNode.getInterfaces(DecompiledClassNode.java:154)
	at org.codehaus.groovy.control.ResolveVisitor.checkCyclicInheritance(ResolveVisitor.java:1373)
	at org.codehaus.groovy.control.ResolveVisitor.visitClass(ResolveVisitor.java:1314)
	at org.codehaus.groovy.control.ResolveVisitor.startResolving(ResolveVisitor.java:258)
	at org.codehaus.groovy.control.CompilationUnit.lambda$addPhaseOperations$3(CompilationUnit.java:207)
	at org.codehaus.groovy.control.CompilationUnit$ISourceUnitOperation.doPhaseOperation(CompilationUnit.java:897)
Caused: BUG! exception in phase 'semantic analysis' in source unit 'WorkflowScript' Unsupported class file major version 69
	at org.codehaus.groovy.control.CompilationUnit$ISourceUnitOperation.doPhaseOperation(CompilationUnit.java:901)
	at org.codehaus.groovy.control.CompilationUnit.processPhaseOperations(CompilationUnit.java:692)
	at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:666)
	at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:373)
	at groovy.lang.GroovyClassLoader.lambda$parseClass$2(GroovyClassLoader.java:316)
	at org.codehaus.groovy.runtime.memoize.StampedCommonCache.compute(StampedCommonCache.java:163)
	at org.codehaus.groovy.runtime.memoize.StampedCommonCache.getAndPut(StampedCommonCache.java:154)
	at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:314)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.GroovySandbox$Scope.parse(GroovySandbox.java:162)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.doParse(CpsGroovyShell.java:202)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.reparse(CpsGroovyShell.java:186)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.parseScript(CpsFlowExecution.java:670)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.start(CpsFlowExecution.java:616)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:344)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:456)
Finished: FAILURE
```

## Fix
- Pins `org.apache.groovy:groovy` to `4.0.29` (ASM 9.9) in test scope to fix this — Groovy 5.x cannot be used as it is incompatible with `groovy-cps`
  - We can't bump `rest-assured` to 6.0.0 because it pulls in Groovy 5.x, and groovy-cps (bundled in workflow-cps) is tightly coupled to the Groovy 4.x
  internal API — it breaks immediately on 5.x with an IllegalAccessError
  - We can't bump `rest-assured` to 5.5.7 because that only gets to Groovy 4.0.22 (ASM 9.7) which still doesn't support Java 25
  - So pinning groovy:4.0.29 directly is the only clean option right now 
  -   When workflow-cps eventually upgrades to support Groovy 5.x, rest-assured 6.0.0 will become an option and the pin can be removed. Until then the pin is
  the right call and the comment in the pom explains exactly why.

## Test
- ran the PCT tests in java 21 and java 25

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/792)
<!-- Reviewable:end -->
