### PR TITLE
Replace rest-assured with Java HttpClient to fix Java 25 PCT failures

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildPlugin(useContainerAgent: true, configurations: [
-    [platform: 'linux', jdk: 21],
-    [platform: 'windows', jdk: 17],
+    [platform: 'linux', jdk: 25],
+    [platform: 'windows', jdk: 21],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
 
         <!--TEST DEPS-->
 
-<dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -128,14 +128,7 @@
 
         <!--TEST DEPS-->
 
-        <!-- 4.5.3 used by rest-assured -->
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>apache-httpcomponents-client-4-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
+<dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
@@ -190,12 +183,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>io.rest-assured</groupId>
-            <artifactId>rest-assured</artifactId>
-            <version>5.3.2</version>
-            <scope>test</scope>
-        </dependency>
 
     </dependencies>
 

--- a/src/test/java/com/cloudbees/jenkins/GitHubWebHookFullTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GitHubWebHookFullTest.java
@@ -61,7 +61,7 @@ public class GitHubWebHookFullTest {
 
     @AfterEach
     void after() throws Exception {
-        if (httpClient instanceof AutoCloseable closeable) {
+        if ((Object) httpClient instanceof AutoCloseable closeable) { // TODO: replace with httpClient.close() once jenkins.baseline is Java 21+
             closeable.close();
         }
     }

--- a/src/test/java/com/cloudbees/jenkins/GitHubWebHookFullTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GitHubWebHookFullTest.java
@@ -52,18 +52,18 @@ public class GitHubWebHookFullTest {
     private JenkinsRule jenkins;
     private HttpClient httpClient;
 
-    @AfterEach
-    void after() throws Exception {
-        if (httpClient instanceof AutoCloseable closeable) {
-            closeable.close();
-        }
-    }
-
     @BeforeEach
     void before(JenkinsRule rule) throws Throwable {
         jenkins = rule;
         jenkins.getInstance().getInjector().injectMembers(this);
         httpClient = HttpClient.newHttpClient();
+    }
+
+    @AfterEach
+    void after() throws Exception {
+        if (httpClient instanceof AutoCloseable closeable) {
+            closeable.close();
+        }
     }
 
     @Test

--- a/src/test/java/com/cloudbees/jenkins/GitHubWebHookFullTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GitHubWebHookFullTest.java
@@ -6,6 +6,7 @@ import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.github.config.GitHubPluginConfig;
 import org.jenkinsci.plugins.github.webhook.GHEventHeader;
 import org.jenkinsci.plugins.github.webhook.GHEventPayload;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -50,6 +51,13 @@ public class GitHubWebHookFullTest {
 
     private JenkinsRule jenkins;
     private HttpClient httpClient;
+
+    @AfterEach
+    void after() throws Exception {
+        if (httpClient instanceof AutoCloseable closeable) {
+            closeable.close();
+        }
+    }
 
     @BeforeEach
     void before(JenkinsRule rule) throws Throwable {

--- a/src/test/java/com/cloudbees/jenkins/GitHubWebHookFullTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GitHubWebHookFullTest.java
@@ -15,9 +15,11 @@ import org.kohsuke.github.GHEvent;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 
 import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static jakarta.servlet.http.HttpServletResponse.SC_METHOD_NOT_ALLOWED;
@@ -91,7 +93,7 @@ public class GitHubWebHookFullTest {
 
     @Test
     void shouldParseFormWebHookOrServiceHookFromGH() throws Exception {
-        String encoded = "payload=" + java.net.URLEncoder.encode(classpath("payloads/push.json"), "UTF-8");
+        String encoded = "payload=" + URLEncoder.encode(classpath("payloads/push.json"), StandardCharsets.UTF_8);
         HttpResponse<String> response = httpClient.send(
                 HttpRequest.newBuilder(URI.create(getPath()))
                         .POST(HttpRequest.BodyPublishers.ofString(encoded))

--- a/src/test/java/com/cloudbees/jenkins/GitHubWebHookFullTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GitHubWebHookFullTest.java
@@ -16,6 +16,7 @@ import org.kohsuke.github.GHEvent;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Locale;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -43,6 +44,7 @@ import static org.jenkinsci.plugins.github.webhook.RequirePostWithGHHookPayload.
 @WithJenkins
 public class GitHubWebHookFullTest {
 
+    // GitHub doesn't send the charset per docs, so re-use the exact content-type from the handler
     public static final String APPLICATION_JSON = GHEventPayload.PayloadHandler.APPLICATION_JSON;
     public static final String FORM = GHEventPayload.PayloadHandler.FORM_URLENCODED;
 
@@ -73,7 +75,7 @@ public class GitHubWebHookFullTest {
                 HttpRequest.newBuilder(URI.create(getPath()))
                         .POST(HttpRequest.BodyPublishers.ofString(classpath("payloads/push.json")))
                         .header("Content-Type", APPLICATION_JSON)
-                        .header(GHEventHeader.PayloadHandler.EVENT_HEADER, GHEvent.PUSH.name().toLowerCase())
+                        .header(GHEventHeader.PayloadHandler.EVENT_HEADER, GHEvent.PUSH.name().toLowerCase(Locale.ROOT))
                         .build(),
                 HttpResponse.BodyHandlers.ofString());
         assertThat("status", response.statusCode(), is(SC_OK));
@@ -91,7 +93,7 @@ public class GitHubWebHookFullTest {
                         .POST(HttpRequest.BodyPublishers.ofString(
                                 classpath(format("payloads/ping_hash_%s_secret_%s.json", hash, secret))))
                         .header("Content-Type", APPLICATION_JSON)
-                        .header(GHEventHeader.PayloadHandler.EVENT_HEADER, GHEvent.PUSH.name().toLowerCase())
+                        .header(GHEventHeader.PayloadHandler.EVENT_HEADER, GHEvent.PUSH.name().toLowerCase(Locale.ROOT))
                         .header(SIGNATURE_HEADER, format("sha1=%s", hash))
                         .header(SIGNATURE_HEADER_SHA256, format("%s%s", SHA256_PREFIX, hash256))
                         .build(),
@@ -106,7 +108,7 @@ public class GitHubWebHookFullTest {
                 HttpRequest.newBuilder(URI.create(getPath()))
                         .POST(HttpRequest.BodyPublishers.ofString(encoded))
                         .header("Content-Type", FORM)
-                        .header(GHEventHeader.PayloadHandler.EVENT_HEADER, GHEvent.PUSH.name().toLowerCase())
+                        .header(GHEventHeader.PayloadHandler.EVENT_HEADER, GHEvent.PUSH.name().toLowerCase(Locale.ROOT))
                         .build(),
                 HttpResponse.BodyHandlers.ofString());
         assertThat("status", response.statusCode(), is(SC_OK));
@@ -118,7 +120,7 @@ public class GitHubWebHookFullTest {
                 HttpRequest.newBuilder(URI.create(getPath()))
                         .POST(HttpRequest.BodyPublishers.ofString(classpath("payloads/ping.json")))
                         .header("Content-Type", APPLICATION_JSON)
-                        .header(GHEventHeader.PayloadHandler.EVENT_HEADER, GHEvent.PING.name().toLowerCase())
+                        .header(GHEventHeader.PayloadHandler.EVENT_HEADER, GHEvent.PING.name().toLowerCase(Locale.ROOT))
                         .build(),
                 HttpResponse.BodyHandlers.ofString());
         assertThat("status", response.statusCode(), is(SC_OK));
@@ -140,7 +142,7 @@ public class GitHubWebHookFullTest {
         HttpResponse<String> response = httpClient.send(
                 HttpRequest.newBuilder(URI.create(getPath()))
                         .POST(HttpRequest.BodyPublishers.noBody())
-                        .header(GHEventHeader.PayloadHandler.EVENT_HEADER, GHEvent.PUSH.name().toLowerCase())
+                        .header(GHEventHeader.PayloadHandler.EVENT_HEADER, GHEvent.PUSH.name().toLowerCase(Locale.ROOT))
                         .build(),
                 HttpResponse.BodyHandlers.ofString());
         assertThat("status", response.statusCode(), is(SC_BAD_REQUEST));

--- a/src/test/java/com/cloudbees/jenkins/GitHubWebHookFullTest.java
+++ b/src/test/java/com/cloudbees/jenkins/GitHubWebHookFullTest.java
@@ -1,10 +1,6 @@
 package com.cloudbees.jenkins;
 
 import com.google.common.base.Charsets;
-import com.google.common.net.HttpHeaders;
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.http.Header;
-import io.restassured.specification.RequestSpecification;
 import jakarta.inject.Inject;
 import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.github.config.GitHubPluginConfig;
@@ -18,20 +14,25 @@ import org.kohsuke.github.GHEvent;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 
-import static io.restassured.RestAssured.given;
-import static io.restassured.config.EncoderConfig.encoderConfig;
-import static io.restassured.config.RestAssuredConfig.newConfig;
 import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static jakarta.servlet.http.HttpServletResponse.SC_METHOD_NOT_ALLOWED;
 import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.ClassUtils.PACKAGE_SEPARATOR;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.jenkinsci.plugins.github.test.HookSecretHelper.removeSecretIn;
 import static org.jenkinsci.plugins.github.test.HookSecretHelper.storeSecretIn;
-import static org.jenkinsci.plugins.github.webhook.RequirePostWithGHHookPayload.Processor.*;
+import static org.jenkinsci.plugins.github.webhook.RequirePostWithGHHookPayload.Processor.SHA256_PREFIX;
+import static org.jenkinsci.plugins.github.webhook.RequirePostWithGHHookPayload.Processor.SIGNATURE_HEADER;
+import static org.jenkinsci.plugins.github.webhook.RequirePostWithGHHookPayload.Processor.SIGNATURE_HEADER_SHA256;
 
 /**
  * @author lanwen (Merkushev Kirill)
@@ -39,46 +40,34 @@ import static org.jenkinsci.plugins.github.webhook.RequirePostWithGHHookPayload.
 @WithJenkins
 public class GitHubWebHookFullTest {
 
-    // GitHub doesn't send the charset per docs, so re-use the exact content-type from the handler
     public static final String APPLICATION_JSON = GHEventPayload.PayloadHandler.APPLICATION_JSON;
     public static final String FORM = GHEventPayload.PayloadHandler.FORM_URLENCODED;
-
-    public static final Header JSON_CONTENT_TYPE = new Header(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON);
-    public static final Header FORM_CONTENT_TYPE = new Header(HttpHeaders.CONTENT_TYPE, FORM);
-    public static final String NOT_NULL_VALUE = "nonnull";
-
-    private RequestSpecification spec;
 
     @Inject
     private GitHubPluginConfig config;
 
     private JenkinsRule jenkins;
+    private HttpClient httpClient;
 
     @BeforeEach
     void before(JenkinsRule rule) throws Throwable {
         jenkins = rule;
         jenkins.getInstance().getInjector().injectMembers(this);
-
-        spec = new RequestSpecBuilder()
-                .setConfig(newConfig()
-                        .encoderConfig(encoderConfig()
-                                .defaultContentCharset(Charsets.UTF_8.name())
-                                // GitHub doesn't add charsets, so don't test with them
-                                .appendDefaultContentCharsetToContentTypeIfUndefined(false)))
-                .build();
+        httpClient = HttpClient.newHttpClient();
     }
 
     @Test
     void shouldParseJsonWebHookFromGH() throws Exception {
         removeSecretIn(config);
-        given().spec(spec)
-                .header(eventHeader(GHEvent.PUSH))
-                .header(JSON_CONTENT_TYPE)
-                .body(classpath("payloads/push.json"))
-                .log().all()
-                .expect().log().all().statusCode(SC_OK).request().post(getPath());
+        HttpResponse<String> response = httpClient.send(
+                HttpRequest.newBuilder(URI.create(getPath()))
+                        .POST(HttpRequest.BodyPublishers.ofString(classpath("payloads/push.json")))
+                        .header("Content-Type", APPLICATION_JSON)
+                        .header(GHEventHeader.PayloadHandler.EVENT_HEADER, GHEvent.PUSH.name().toLowerCase())
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat("status", response.statusCode(), is(SC_OK));
     }
-
 
     @Test
     void shouldParseJsonWebHookFromGHWithSignHeader() throws Exception {
@@ -87,89 +76,91 @@ public class GitHubWebHookFullTest {
         String secret = "123";
 
         storeSecretIn(config, secret);
-        given().spec(spec)
-                .header(eventHeader(GHEvent.PUSH))
-                .header(JSON_CONTENT_TYPE)
-                .header(SIGNATURE_HEADER, format("sha1=%s", hash))
-                .header(SIGNATURE_HEADER_SHA256, format("%s%s", SHA256_PREFIX, hash256))
-                .body(classpath(String.format("payloads/ping_hash_%s_secret_%s.json", hash, secret)))
-                .log().all()
-                .expect().log().all().statusCode(SC_OK).request().post(getPath());
+        HttpResponse<String> response = httpClient.send(
+                HttpRequest.newBuilder(URI.create(getPath()))
+                        .POST(HttpRequest.BodyPublishers.ofString(
+                                classpath(format("payloads/ping_hash_%s_secret_%s.json", hash, secret))))
+                        .header("Content-Type", APPLICATION_JSON)
+                        .header(GHEventHeader.PayloadHandler.EVENT_HEADER, GHEvent.PUSH.name().toLowerCase())
+                        .header(SIGNATURE_HEADER, format("sha1=%s", hash))
+                        .header(SIGNATURE_HEADER_SHA256, format("%s%s", SHA256_PREFIX, hash256))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat("status", response.statusCode(), is(SC_OK));
     }
 
     @Test
     void shouldParseFormWebHookOrServiceHookFromGH() throws Exception {
-        given().spec(spec)
-                .header(eventHeader(GHEvent.PUSH))
-                .header(FORM_CONTENT_TYPE)
-                .formParam("payload", classpath("payloads/push.json"))
-                .log().all()
-                .expect().log().all().statusCode(SC_OK).request().post(getPath());
+        String encoded = "payload=" + java.net.URLEncoder.encode(classpath("payloads/push.json"), "UTF-8");
+        HttpResponse<String> response = httpClient.send(
+                HttpRequest.newBuilder(URI.create(getPath()))
+                        .POST(HttpRequest.BodyPublishers.ofString(encoded))
+                        .header("Content-Type", FORM)
+                        .header(GHEventHeader.PayloadHandler.EVENT_HEADER, GHEvent.PUSH.name().toLowerCase())
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat("status", response.statusCode(), is(SC_OK));
     }
 
     @Test
     void shouldParsePingFromGH() throws Exception {
-        given().spec(spec)
-                .header(eventHeader(GHEvent.PING))
-                .header(JSON_CONTENT_TYPE)
-                .body(classpath("payloads/ping.json"))
-                .log().all()
-                .expect().log().all()
-                .statusCode(SC_OK)
-                .request()
-                .post(getPath());
+        HttpResponse<String> response = httpClient.send(
+                HttpRequest.newBuilder(URI.create(getPath()))
+                        .POST(HttpRequest.BodyPublishers.ofString(classpath("payloads/ping.json")))
+                        .header("Content-Type", APPLICATION_JSON)
+                        .header(GHEventHeader.PayloadHandler.EVENT_HEADER, GHEvent.PING.name().toLowerCase())
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat("status", response.statusCode(), is(SC_OK));
     }
 
     @Test
     void shouldReturnErrOnEmptyPayloadAndHeader() throws Exception {
-        given().spec(spec)
-                .log().all()
-                .expect().log().all()
-                .statusCode(SC_BAD_REQUEST)
-                .body(containsString("Hook should contain event type"))
-                .request()
-                .post(getPath());
+        HttpResponse<String> response = httpClient.send(
+                HttpRequest.newBuilder(URI.create(getPath()))
+                        .POST(HttpRequest.BodyPublishers.noBody())
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat("status", response.statusCode(), is(SC_BAD_REQUEST));
+        assertThat("body", response.body(), containsString("Hook should contain event type"));
     }
 
     @Test
     void shouldReturnErrOnEmptyPayload() throws Exception {
-        given().spec(spec)
-                .header(eventHeader(GHEvent.PUSH))
-                .log().all()
-                .expect().log().all()
-                .statusCode(SC_BAD_REQUEST)
-                .body(containsString("Hook should contain payload"))
-                .request()
-                .post(getPath());
+        HttpResponse<String> response = httpClient.send(
+                HttpRequest.newBuilder(URI.create(getPath()))
+                        .POST(HttpRequest.BodyPublishers.noBody())
+                        .header(GHEventHeader.PayloadHandler.EVENT_HEADER, GHEvent.PUSH.name().toLowerCase())
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat("status", response.statusCode(), is(SC_BAD_REQUEST));
+        assertThat("body", response.body(), containsString("Hook should contain payload"));
     }
 
     @Test
     void shouldReturnErrOnGetReq() throws Exception {
-        given().spec(spec)
-                .log().all().expect().log().all()
-                .statusCode(SC_METHOD_NOT_ALLOWED)
-                .request()
-                .get(getPath());
+        HttpResponse<String> response = httpClient.send(
+                HttpRequest.newBuilder(URI.create(getPath()))
+                        .GET()
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat("status", response.statusCode(), is(SC_METHOD_NOT_ALLOWED));
     }
 
     @Test
     void shouldProcessSelfTest() throws Exception {
-        given().spec(spec)
-                .header(new Header(GitHubWebHook.URL_VALIDATION_HEADER, NOT_NULL_VALUE))
-                .log().all()
-                .expect().log().all()
-                .statusCode(SC_OK)
-                .header(GitHubWebHook.X_INSTANCE_IDENTITY, notNullValue())
-                .request()
-                .post(getPath());
+        HttpResponse<String> response = httpClient.send(
+                HttpRequest.newBuilder(URI.create(getPath()))
+                        .POST(HttpRequest.BodyPublishers.noBody())
+                        .header(GitHubWebHook.URL_VALIDATION_HEADER, "nonnull")
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat("status", response.statusCode(), is(SC_OK));
+        assertThat("identity header", response.headers().firstValue(GitHubWebHook.X_INSTANCE_IDENTITY).orElse(null), notNullValue());
     }
 
-    public Header eventHeader(GHEvent event) {
-        return eventHeader(event.name().toLowerCase());
-    }
-
-    public Header eventHeader(String event) {
-        return new Header(GHEventHeader.PayloadHandler.EVENT_HEADER, event);
+    private String getPath() {
+        return jenkins.getInstance().getRootUrl() + GitHubWebHook.URLNAME.concat("/");
     }
 
     public static String classpath(String path) {
@@ -184,9 +175,5 @@ public class GitHubWebHookFullTest {
         } catch (IOException e) {
             throw new RuntimeException(format("Can't load %s for class %s", path, clazz), e);
         }
-    }
-
-    private String getPath(){
-        return jenkins.getInstance().getRootUrl() + GitHubWebHook.URLNAME.concat("/");
     }
 }


### PR DESCRIPTION
## What are we fixing?

The github-plugin PCT tests fail when run against a Java 25 JVM. Fixes #783

`rest-assured:5.3.2` transitively pulls in `org.apache.groovy:groovy:4.0.11`. Groovy 4.x introduced `asmResolving=true` as the default class resolution strategy, which calls `AsmDecompiler` before the classloader. When the test runs on Java 25, `GroovyClassLoader` compiles `WorkflowScript` at major version 69 at runtime. ASM 9.5 (bundled in `groovy:4.0.11`) only supports up to version 64 — version 69 exceeds that ceiling, causing:

```
IllegalArgumentException: Unsupported class file major version 69
```

See [CloudBees-internal reference](https://cloudbees.atlassian.net/browse/BEE-71990) for full root cause analysis.

## RCA
1. The github-plugin is compiled with --release 17, producing class files at major version 61
2. rest-assured:5.3.2 (test-only dependency) transitively pulls in groovy:4.0.11, which bundles ASM 9.5 (supports class files up to Java 21)
3. When running PCT on Java 25, GitHubPushTriggerTest#shouldStartWorkflowByTrigger calls [jRule.assertBuildStatusSuccess(job.scheduleBuild2(0))](https://github.com/jenkinsci/github-plugin/blob/8e3b0160fdaee58c6d09fe6743567bae88819aa0/src/test/java/com/cloudbees/jenkins/GitHubPushTriggerTest.java#L67)
4. AFAICT, This triggers CpsGroovyShell.reparse() → GroovyClassLoader.parseClass("node { git '...' }") — compiled at runtime on the Java 25 JVM — producing WorkflowScript.class at major version 69
5. Groovy 4.0.11 introduced asmResolving=true as the default resolution strategy, meaning it calls AsmDecompiler before the classloader: [ClassNodeResolver.java#L193](https://github.com/apache/groovy/blob/698c68e35c8825d96360075b4e5f6f92ca0e0338/src/main/java/org/codehaus/groovy/control/ClassNodeResolver.java#L193)
6. ASM 9.5 ceiling is version 64. Version 69 exceeds it → IllegalArgumentException: Unsupported class file major version 69

**Why other plugins are not affected?**
Other plugins don't have rest-assured as a test dependency, so groovy:4.0.11 is never on their test classpath. They have  groovy-all:2.4.21 from Jenkins core , which uses a classloader-first resolution strategy and never calls AsmDecompiler in this path: [ClassNodeResolver.java#L178](https://github.com/apache/groovy/blob/41b990d0a20e442f29247f0e04cbed900f3dcad4/src/main/org/codehaus/groovy/control/ClassNodeResolver.java#L178)

8. ## Changes

1. Replace `rest-assured` with Java's built-in `java.net.http.HttpClient` in `GitHubWebHookFullTest`. `rest-assured` was only used in that one test class for plain HTTP request/response assertions — no Groovy-dependent features (xml-path/json-path) were used. Removing it eliminates the transitive `groovy:4.0.11` dependency entirely.


2. Test with Java 25 and Java 21, Java 25 released September 16, 2025. The Jenkins project wants to support Java 25 soon. Compile and test on ci.jenkins.io with Java 25 and Java 21.
Intentionally continues to generate Java 17 byte code as configured by the plugin parent pom.
Does not compile or test with Java 17 any longer because we have found no issues in the past that were specific to the Java 17 compiler. The plan is to drop support for Java 17 in the not too distant future so that the Jenkins project is only supporting two major Java versions at a time, Java 21 and Java 25.



## Test
- Ran PCT locally tests in java 21 and java 25
-   Since I don't have write access to this repo, the updated Jenkinsfile (Java 25/21) won't take effect in CI until merged. If someone with write access could trigger a build replay with the updated Jenkinsfile, that would confirm Java 25 compatibility in CI as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-plugin/793)
<!-- Reviewable:end -->
